### PR TITLE
Code style

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+**/node_modules/*
+frontend-material/src/components

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/node_modules/*
 frontend-material/src/components
+frontend-material/src/assets/jss

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,37 +4,25 @@ env:
   node: true
 extends:
   - 'eslint:recommended'
-  - 'plugin:react/recommended'
 globals:
   Atomics: readonly
   SharedArrayBuffer: readonly
 parserOptions:
-  ecmaFeatures:
-    jsx: true
   ecmaVersion: 2018
-  sourceType: module
-overrides:
-  - files:
-    - backend/**.js
-    parserOptions:
-      sourceType: script
-plugins:
-  - react
-settings:
-  react:
-    version: '16.10'
+  sourceType: script
 rules:
   no-unused-vars:
     - off
   indent:
     - warn
-    - 2
+    - 4
   linebreak-style:
     - off
     - unix
   quotes:
     - warn
     - single
+    - avoid-escape
   semi:
     - warn
     - always
@@ -84,5 +72,6 @@ rules:
     - warn
   eqeqeq:
     - warn
-  react/prop-types:
+    - smart
+  no-console:
     - off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,88 @@
+env:
+  browser: true
+  es6: true
+  node: true
+extends:
+  - 'eslint:recommended'
+  - 'plugin:react/recommended'
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+parserOptions:
+  ecmaFeatures:
+    jsx: true
+  ecmaVersion: 2018
+  sourceType: module
+overrides:
+  - files:
+    - backend/**.js
+    parserOptions:
+      sourceType: script
+plugins:
+  - react
+settings:
+  react:
+    version: '16.10'
+rules:
+  no-unused-vars:
+    - off
+  indent:
+    - warn
+    - 2
+  linebreak-style:
+    - off
+    - unix
+  quotes:
+    - warn
+    - single
+  semi:
+    - warn
+    - always
+  block-spacing:
+    - warn
+    - always
+  object-curly-spacing:
+    - warn
+    - always
+  array-bracket-spacing:
+    - warn
+    - never
+  no-var:
+    - warn
+  no-trailing-spaces:
+    - warn
+  no-whitespace-before-property:
+    - warn
+  semi-spacing:
+    - warn
+  semi-style:
+    - warn
+  space-in-parens:
+    - warn
+    - never
+  space-before-blocks:
+    - warn
+    - always
+  space-before-function-paren:
+    - warn
+    - never
+  space-unary-ops:
+    - warn
+  spaced-comment:
+    - warn
+    - always
+  comma-spacing:
+    - warn
+  comma-style:
+    - warn
+    - last
+  brace-style:
+    - warn
+    - 1tbs
+    - allowSingleLine: true
+  key-spacing:
+    - warn
+  eqeqeq:
+    - warn
+  react/prop-types:
+    - off

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ The backend starts by running server.js.
 Message [Bryce](https://github.com/Navbryce) if you have questions [about the API docs](https://app.swaggerhub.com/apis-docs/navbryce/irc/1.0.0)
 
 ## Code Style
-Run `npx eslint --fix /path_to/irc/` to check and fix the style of your code. Use semicolons and single quotes. See .eslintrc.yml and .eslintignore for details on the style guidelines.
+Run `npx eslint --fix /path_to/irc/` or `npx eslint --ext js,jsx --fix /path_to/irc/` (including .jsx files) to check and fix the style of your code. Use semicolons and single quotes. See .eslintrc.yml, frontend-material/.eslintrc.yml, and .eslintignore for details on the style guidelines. If you're getting an error from a trash style guideline, you can add `    name-of-style-error: off` to the bottom of .eslintrc.yml.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ The backend starts by running server.js.
 
 ## Backend API Docs
 Message [Bryce](https://github.com/Navbryce) if you have questions [about the API docs](https://app.swaggerhub.com/apis-docs/navbryce/irc/1.0.0)
+
+## Code Style
+Run `npx eslint --fix /path_to/irc/` to check and fix the style of your code. Use semicolons and single quotes. See .eslintrc.yml and .eslintignore for details on the style guidelines.

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ The backend starts by running server.js.
 Message [Bryce](https://github.com/Navbryce) if you have questions [about the API docs](https://app.swaggerhub.com/apis-docs/navbryce/irc/1.0.0)
 
 ## Code Style
-Run `npx eslint --fix /path_to/irc/` or `npx eslint --ext js,jsx --fix /path_to/irc/` (including .jsx files) to check and fix the style of your code. Use semicolons and single quotes. See .eslintrc.yml, frontend-material/.eslintrc.yml, and .eslintignore for details on the style guidelines. If you're getting an error from a trash style guideline, you can add `    name-of-style-error: off` to the bottom of .eslintrc.yml.
+Run `npx eslint --fix /path_to/irc/` or `npx eslint --ext js,jsx --fix /path_to/irc/` (including .jsx files) to check and fix the style of your code. Use semicolons and single quotes. See .eslintrc.yml, frontend-material/.eslintrc.yml, and .eslintignore for details on the style guidelines. If eslint is throwing up an error based on a bad style guideline, you can add `  name-of-style-error: off` to the bottom of .eslintrc.yml.

--- a/backend/auth/passport.js
+++ b/backend/auth/passport.js
@@ -6,50 +6,50 @@ const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
 const UserModel = require('../model/user');
 
-const passportJWT = require("passport-jwt");
+const passportJWT = require('passport-jwt');
 const JWTStrategy   = passportJWT.Strategy;
 const ExtractJWT = passportJWT.ExtractJwt;
 
 module.exports = function(passport) {
     passport.use(new JWTstrategy({
-      secretOrKey : 'dragonsandpandas',
-      jwtFromRequest : ExtractJWT.fromAuthHeaderAsBearerToken(),
-    }, async (token, done) => {
-      try {
-        return done(null, token.user);
-      } catch (error) {
-        done(error);
-      }
+        secretOrKey: 'dragonsandpandas',
+        jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
+    }, async(token, done) => {
+        try {
+            return done(null, token.user);
+        } catch (error) {
+            done(error);
+        }
     }));
 
     passport.use('signup', new LocalStrategy({
-      usernameField : 'email',
-      passwordField : 'password'
-    }, async (email, password, done) => {
+        usernameField: 'email',
+        passwordField: 'password'
+    }, async(email, password, done) => {
         try {
-          const user = await UserModel.create({ email, password });
-          return done(null, user);
+            const user = await UserModel.create({ email, password });
+            return done(null, user);
         } catch (error) {
-          done(error);
+            done(error);
         }
     }));
 
     passport.use('login', new LocalStrategy({
-      usernameField : 'email',
-      passwordField : 'password'
-    }, async (email, password, done) => {
-      try {
-        const user = await UserModel.findOne({ email });
-        if( !user ){
-          return done(null, false, { message : 'User not found'});
+        usernameField: 'email',
+        passwordField: 'password'
+    }, async(email, password, done) => {
+        try {
+            const user = await UserModel.findOne({ email });
+            if(!user) {
+                return done(null, false, { message: 'User not found' });
+            }
+            const validate = await user.isValidPassword(password);
+            if(!validate) {
+                return done(null, false, { message: 'Wrong Password' });
+            }
+            return done(null, user, { message: 'Logged in Successfully' });
+        } catch (error) {
+            return done(error);
         }
-        const validate = await user.isValidPassword(password);
-        if( !validate ){
-          return done(null, false, { message : 'Wrong Password'});
-        }
-        return done(null, user, { message : 'Logged in Successfully'});
-      } catch (error) {
-        return done(error);
-      }
     }));
-}
+};

--- a/backend/auth/passport.js
+++ b/backend/auth/passport.js
@@ -11,7 +11,7 @@ const JWTStrategy   = passportJWT.Strategy;
 const ExtractJWT = passportJWT.ExtractJwt;
 
 module.exports = function(passport) {
-    passport.use(new JWTstrategy({
+    passport.use(new JWTStrategy({
         secretOrKey: 'dragonsandpandas',
         jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
     }, async(token, done) => {

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,7 +1,7 @@
-let config = {}
+let config = {};
 
 config.port = 5000;
-config.db_path = "hello";
-config.db_url = `mongodb://localhost:27017/${config.db_path}`
+config.db_path = 'hello';
+config.db_url = `mongodb://localhost:27017/${config.db_path}`;
 
 module.exports = config;

--- a/backend/config/permissions-processor.js
+++ b/backend/config/permissions-processor.js
@@ -27,16 +27,16 @@ function formatPermissions(rawPermissions) {
 }
 function findGroupWithCompleteDependencies(groupNames, rawPerms, finalizedPerms) {
     const index = groupNames.findIndex((groupName) => {
-       const group = rawPerms[groupName];
-       let dependenciesComplete = true;
-       if (group.inherit != null) {
-           group.inherit.forEach((depndentGroup) => {
-              if (finalizedPerms[depndentGroup] == null) {
-                  dependenciesComplete = false;
-              }
-           });
-       }
-       return dependenciesComplete;
+        const group = rawPerms[groupName];
+        let dependenciesComplete = true;
+        if (group.inherit != null) {
+            group.inherit.forEach((depndentGroup) => {
+                if (finalizedPerms[depndentGroup] == null) {
+                    dependenciesComplete = false;
+                }
+            });
+        }
+        return dependenciesComplete;
     });
     let output = null;
     if (index >= 0) {

--- a/backend/model/transaction.js
+++ b/backend/model/transaction.js
@@ -40,15 +40,15 @@ const TransactionSchema = new Schema({
  * @param itemType EITHER 'VOLUNTEER' or 'SHOP'
  */
 TransactionSchema.statics.getItemsByType = async function(itemType) {
-    return this.find({type: itemType})
+    return this.find({ type: itemType });
 };
 
 TransactionSchema.statics.getShopItems = async function() {
-    return this.getItemsByType("SHOP");
+    return this.getItemsByType('SHOP');
 };
 
 TransactionSchema.statics.getVolunteerItems = async function() {
-    return this.getItemsByType("VOLUNTEER");
+    return this.getItemsByType('VOLUNTEER');
 };
 
 const Transaction = mongoose.model('Transaction', TransactionSchema);

--- a/backend/model/user.js
+++ b/backend/model/user.js
@@ -14,77 +14,77 @@ const bcrypt = require('bcrypt');
 const Schema = mongoose.Schema;
 
 const UserSchema = new Schema({
-  email: {
-    type: String,
-    required: true,
-    unique: true
-  },
-  password: {
-    type: String,
-    required: true
-  },
-  permissionGroup: {
-    type: String,
-    required: true,
-    default: 'user',
-  },
-  firstName: {
-    type: String,
-    required: false,
-    default: 'N/A'
-  },
-  lastName: {
-    type: String,
-    required: false,
-    default: 'N/A'
-  }
+    email: {
+        type: String,
+        required: true,
+        unique: true
+    },
+    password: {
+        type: String,
+        required: true
+    },
+    permissionGroup: {
+        type: String,
+        required: true,
+        default: 'user',
+    },
+    firstName: {
+        type: String,
+        required: false,
+        default: 'N/A'
+    },
+    lastName: {
+        type: String,
+        required: false,
+        default: 'N/A'
+    }
 });
 
-UserSchema.pre('save', async function (next) {
-  const hash = await bcrypt.hash(this.password, 10);
-  this.password = hash;
-  next();
+UserSchema.pre('save', async function(next) {
+    const hash = await bcrypt.hash(this.password, 10);
+    this.password = hash;
+    next();
 });
 
-UserSchema.methods.isValidPassword = async function (password) {
-  const user = this;
-  const compare = await bcrypt.compare(password, user.password);
-  return compare
+UserSchema.methods.isValidPassword = async function(password) {
+    const user = this;
+    const compare = await bcrypt.compare(password, user.password);
+    return compare;
 };
 
 /**
  *
  * @returns {*}
  */
-UserSchema.methods.getPermissionsGroup = function () {
-  return permissionsGroupMap[this.permissionGroup];
+UserSchema.methods.getPermissionsGroup = function() {
+    return permissionsGroupMap[this.permissionGroup];
 };
 
 /**
  * Gets the user's permission group
  * @returns {{}}
  */
-UserSchema.methods.getPermissionsGroup = function () {
-  return permissionsGroupMap[this.permissionGroup];
+UserSchema.methods.getPermissionsGroup = function() {
+    return permissionsGroupMap[this.permissionGroup];
 };
 
 /**
  * Returns a map (javascript dictionary) where every key is a permission the user has
  * @returns {{}}
  */
-UserSchema.methods.getPermissionsMap =  function () {
-  return this.getPermissionsGroup().permissionMap;
+UserSchema.methods.getPermissionsMap =  function() {
+    return this.getPermissionsGroup().permissionMap;
 };
 
-UserSchema.methods.hasPermission = function (permission) {
-  return this.getPermissionsMap()[permission] != null;
+UserSchema.methods.hasPermission = function(permission) {
+    return this.getPermissionsMap()[permission] != null;
 };
 UserSchema.methods.getPermissions = function() {
-  return Object.keys(this.getPermissionsMap());
+    return Object.keys(this.getPermissionsMap());
 };
 
 UserSchema.statics.getCount = async function() {
-  return this.countDocuments({});
+    return this.countDocuments({});
 };
 
 const UserModel = mongoose.model('User', UserSchema);

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -3,14 +3,14 @@
 //
 const express = require('express');
 const router = express.Router({});
-const transactionsApi = require('./transactions-router')
+const transactionsApi = require('./transactions-router');
 const userApi = require('./user-router');
 
 const Client = require('../model/client');
 
 const passport = require('passport');
 const jwt = require('jsonwebtoken');
-const passportJWT = require("passport-jwt");
+const passportJWT = require('passport-jwt');
 const JWTStrategy = passportJWT.Strategy;
 const ExtractJWT = passportJWT.ExtractJwt;
 
@@ -33,62 +33,62 @@ const UserDB = mongoose.model('User', UserModel.__Schema);
 
 const LocalStrategy = require('passport-local').Strategy;
 
-const bodyParser = require("body-parser");
+const bodyParser = require('body-parser');
 router.use(bodyParser.urlencoded({ extended: true }));
 router.use(bodyParser.json());
 
 const jwtStrategy = new JWTStrategy({
-  secretOrKey: config.JWT_SECRET,
-  jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken()
-}, async function (token, done) {
-  try {
-    const decoded = await jwt.verify(token, config.JWT_SECRET);
-    const email = decoded.email;
-    const password = decoded.password;
-    const user = await UserDB.findOne({ email });
-    if (!user) {
-      return done(null, false, response.generateUserNotFoundError(email));
-    }
-    const validate = await user.isValidPassword(password);
-    if (!validate) {
-      return done(null, false, { message: 'Wrong Password' });
-    }
-    const token = await jwt.sign({ email, password }, config.JWT_SECRET);
+    secretOrKey: config.JWT_SECRET,
+    jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken()
+}, async function(token, done) {
+    try {
+        const decoded = await jwt.verify(token, config.JWT_SECRET);
+        const email = decoded.email;
+        const password = decoded.password;
+        const user = await UserDB.findOne({ email });
+        if (!user) {
+            return done(null, false, response.generateUserNotFoundError(email));
+        }
+        const validate = await user.isValidPassword(password);
+        if (!validate) {
+            return done(null, false, { message: 'Wrong Password' });
+        }
+        const token = await jwt.sign({ email, password }, config.JWT_SECRET);
 
-    return done(null, user,
-      { message: 'Logged in Successfully', token,
-      errorCode: OK_CODE });
-  } catch (error) {
-    return done(error);
-  }
+        return done(null, user,
+            { message: 'Logged in Successfully', token,
+                errorCode: OK_CODE });
+    } catch (error) {
+        return done(error);
+    }
 });
 
 const loginStrategy = new LocalStrategy({
-  usernameField: 'email',
-  passwordField: 'password',
-  passReqToCallback: true,
-}, async function (req, email, password, done) {
-  try {
-    const user = await UserDB.findOne({ email });
-    if (!user) {
-      return done(null, false, response.generateUserNotFoundError(email));
+    usernameField: 'email',
+    passwordField: 'password',
+    passReqToCallback: true,
+}, async function(req, email, password, done) {
+    try {
+        const user = await UserDB.findOne({ email });
+        if (!user) {
+            return done(null, false, response.generateUserNotFoundError(email));
+        }
+        const validate = await user.isValidPassword(password);
+        if (!validate) {
+            const message = 'Incorrect password';
+            const errorCode = 400;
+            const error = 'Error 400 - Bad Request - Wrong password for user';
+            return done(null, false, response.generateResponseMessage(message, errorCode, error));
+        }
+        const token = await jwt.sign({ email, password }, config.JWT_SECRET);
+        const messageBody = {
+            token
+        };
+        return done(null, user,
+            response.generateOkResponse('Logged in successfully', messageBody));
+    } catch (error) {
+        return done(error);
     }
-    const validate = await user.isValidPassword(password);
-    if (!validate) {
-      const message = "Incorrect password"
-      const errorCode = 400;
-      const error = "Error 400 - Bad Request - Wrong password for user";
-      return done(null, false, response.generateResponseMessage(message, errorCode, error));
-    }
-    const token = await jwt.sign({ email, password }, config.JWT_SECRET);
-    const messageBody = {
-      token
-    }
-    return done(null, user,
-      response.generateOkResponse("Logged in successfully", messageBody));
-  } catch (error) {
-    return done(error);
-  }
 });
 
 /**
@@ -100,145 +100,145 @@ const loginStrategy = new LocalStrategy({
  * BE CAREFUL WHEN CALLING THIS METHOD: SIGNS TOKENS AS VALID
  */
 async function signToken(res, email, password) {
-  const token = await jwt.sign({ email, password }, config.JWT_SECRET);
-  res.cookie("token", token);
-  return token;
+    const token = await jwt.sign({ email, password }, config.JWT_SECRET);
+    res.cookie('token', token);
+    return token;
 }
 
 passport.use('login', loginStrategy);
-passport.use("jwt", jwtStrategy);
+passport.use('jwt', jwtStrategy);
 
-router.post('/signup', function (req, res) {
-  UserDB.create(req.body, async function (err, newUser) {
-    if (err) {
-      if (err.code === 11000) {
-        return res.json(response.generateResponseMessage(
-          "User with that email already exists.",
-          409,
-          "Error 409 - Conflict with current resource - A user with" +
-          " that e-mail already exists.",
-          {
-            complete: false,
-          }
-        ));
-      }
-      if (err.errors) {
-        const response = response.generateResponseMessage(
-          `The following required fields are missing: ${Object.keys(err.errors).join(", ")}`,
-          400,
-          "Error 400 - Invalid syntax when trying to signup",
-          {complete: false}
-        )
-        return res.json(response)
-      }
+router.post('/signup', function(req, res) {
+    UserDB.create(req.body, async function(err, newUser) {
+        if (err) {
+            if (err.code === 11000) {
+                return res.json(response.generateResponseMessage(
+                    'User with that email already exists.',
+                    409,
+                    'Error 409 - Conflict with current resource - A user with' +
+          ' that e-mail already exists.',
+                    {
+                        complete: false,
+                    }
+                ));
+            }
+            if (err.errors) {
+                const response = response.generateResponseMessage(
+                    `The following required fields are missing: ${Object.keys(err.errors).join(', ')}`,
+                    400,
+                    'Error 400 - Invalid syntax when trying to signup',
+                    { complete: false }
+                );
+                return res.json(response);
+            }
 
-      return res.json(response.generateResponseMessage("Internal server error", 500,
-      error = "Error 500 - Internal Server Error - Line 114 in main route."))
+            return res.json(response.generateResponseMessage('Internal server error', 500,
+                error = 'Error 500 - Internal Server Error - Line 114 in main route.'));
 
-    }
+        }
 
-    // Account created. Redirect to login
-    const email = newUser.email;
+        // Account created. Redirect to login
+        const email = newUser.email;
 
-    const params = {
-      complete: true,
-      userVerify: true,
-      urlRedirect: "dashboard",
-      setCookies: { token: null }
-    };
-    const message = response.generateOkResponse("Success", params);
-    return res.json(message)
-  });
+        const params = {
+            complete: true,
+            userVerify: true,
+            urlRedirect: 'dashboard',
+            setCookies: { token: null }
+        };
+        const message = response.generateOkResponse('Success', params);
+        return res.json(message);
+    });
 });
 
-router.post('/login', function (req, res) {
-  passport.authenticate('login', { session: false }, async function (err, user, returnMsg) {
-    if (!user) {
-      // concat the return message with the complete: false parameter
-      res.json(Object.assign({}, returnMsg, {complete: false}));
-      return;
-    }
-    const token = await signToken(res, req.body.email, req.body.password);
-    const messageBody = {
-      complete: true,
-      userVerify: true,
-      urlRedirect: "dashboard",
-      setCookies: { token },
-    };
-    res.json(response.generateOkResponse("Login success", messageBody));
-  })(req, res);
+router.post('/login', function(req, res) {
+    passport.authenticate('login', { session: false }, async function(err, user, returnMsg) {
+        if (!user) {
+            // concat the return message with the complete: false parameter
+            res.json(Object.assign({}, returnMsg, { complete: false }));
+            return;
+        }
+        const token = await signToken(res, req.body.email, req.body.password);
+        const messageBody = {
+            complete: true,
+            userVerify: true,
+            urlRedirect: 'dashboard',
+            setCookies: { token },
+        };
+        res.json(response.generateOkResponse('Login success', messageBody));
+    })(req, res);
 });
 
-router.post('/verify', async function (req, res, next) {
-  try {
-    const encodedToken = req.cookies.token || req.body.token ||
-    (() => { throw response.generateTokenError() })();
-    const decodedToken = await jwt.verify(encodedToken, config.JWT_SECRET);
+router.post('/verify', async function(req, res, next) {
+    try {
+        const encodedToken = req.cookies.token || req.body.token ||
+    (() => { throw response.generateTokenError(); })();
+        const decodedToken = await jwt.verify(encodedToken, config.JWT_SECRET);
 
-    const email = decodedToken.email;
-    const password = decodedToken.password;
+        const email = decodedToken.email;
+        const password = decodedToken.password;
 
-    const user = await UserDB.findOne({ email })
-      || (() => { throw response.generateUserNotFoundError(email) })();
-    const validate = await user.isValidPassword(password);
+        const user = await UserDB.findOne({ email })
+      || (() => { throw response.generateUserNotFoundError(email); })();
+        const validate = await user.isValidPassword(password);
 
-    if (user && validate) {
-      const params = {
-        userVerify: true,
-        user: {
-          _id: user._id,
-          email: user.email,
-          firstName: user.firstName,
-          lastName: user.lastName,
-         }
-      };
-      return res.json(response.generateOkResponse("Verify success", params));
-    }
-    const message = "Could not validate user";
-    const errorCode = 400
-    const error = "Error 400 - Bad Request - Could not validate user. Bad password.";
-    const params = {
-      userVerify: false,
-      urlRedirect: "login",
-    };
-    return res.json(response.generateResponseMessage(message, errorCode, error, params));
-  } catch (error) {
+        if (user && validate) {
+            const params = {
+                userVerify: true,
+                user: {
+                    _id: user._id,
+                    email: user.email,
+                    firstName: user.firstName,
+                    lastName: user.lastName,
+                }
+            };
+            return res.json(response.generateOkResponse('Verify success', params));
+        }
+        const message = 'Could not validate user';
+        const errorCode = 400;
+        const error = 'Error 400 - Bad Request - Could not validate user. Bad password.';
+        const params = {
+            userVerify: false,
+            urlRedirect: 'login',
+        };
+        return res.json(response.generateResponseMessage(message, errorCode, error, params));
+    } catch (error) {
     // errors aligns with message format already
-    const params = {
-      userVerify: false,
-      urlRedirect: "login",
-    };
-    return res.json(Object.assign({}, error, params)); // concat msg and params
-  }
+        const params = {
+            userVerify: false,
+            urlRedirect: 'login',
+        };
+        return res.json(Object.assign({}, error, params)); // concat msg and params
+    }
 });
 
-router.use(async function (req, res, next) {
-  try {
-    const encodedToken = req.cookies.token || req.body.token ||
-      (() => { throw response.generateTokenError() })();
-    const decodedToken = await jwt.verify(encodedToken, config.JWT_SECRET);
+router.use(async function(req, res, next) {
+    try {
+        const encodedToken = req.cookies.token || req.body.token ||
+      (() => { throw response.generateTokenError(); })();
+        const decodedToken = await jwt.verify(encodedToken, config.JWT_SECRET);
 
-    const email = decodedToken.email;
-    const password = decodedToken.password;
+        const email = decodedToken.email;
+        const password = decodedToken.password;
 
-    const user = await UserDB.findOne({ email }) ||
-    (() => { throw response.generateUserNotFoundError(email)})();
+        const user = await UserDB.findOne({ email }) ||
+    (() => { throw response.generateUserNotFoundError(email); })();
 
-    const validate = await user.isValidPassword(password) || (() => {
-      const message = 'The user\'s account has not been verified'
-      const errorCode = 400;
-      const errorMessage = 'Error 400 - Bad Request - The user could not be verified'
-      throw response.generateResponseMessage(message, errorCode, errorMessage);
-    })();
+        const validate = await user.isValidPassword(password) || (() => {
+            const message = 'The user\'s account has not been verified';
+            const errorCode = 400;
+            const errorMessage = 'Error 400 - Bad Request - The user could not be verified';
+            throw response.generateResponseMessage(message, errorCode, errorMessage);
+        })();
 
-    // if the user, continue with the res
-    res.locals.user = user;
-    return next(null, user);
-  } catch (error) {
+        // if the user, continue with the res
+        res.locals.user = user;
+        return next(null, user);
+    } catch (error) {
     // assume the error conforms to the message requirements
-    const params = {userVerify: false, urlRedirect: "login"}
-    return res.json(Object.assign({}, error, params));
-  }
+        const params = { userVerify: false, urlRedirect: 'login' };
+        return res.json(Object.assign({}, error, params));
+    }
 });
 
 
@@ -248,49 +248,49 @@ router.use('/transactions', transactionsApi);
 
 // TODO: MOVE THIS ROUTE TO THE USER-ROUTER AND/OR A ROUTER DEDICATED TO LOGGIN IN
 router.post('/changePassword', async function(req, res, next) {
-  const user = res.locals.user;
-  let returnMessage;
-  if (!user) {
-    returnMessage =
-    response.generateResponseMessage("The user object could not be found in the"
-    + " request", 400);
-  } else {
-    const newPassword = req.body.password;
-    if (!newPassword) {
-      returnMessage =
-      response.generateResponseMessage("No new password specified under the 'passwprd'"
-      + " field", 400);
+    const user = res.locals.user;
+    let returnMessage;
+    if (!user) {
+        returnMessage =
+    response.generateResponseMessage('The user object could not be found in the'
+    + ' request', 400);
     } else {
-      user.password = newPassword;
-      user.save();
-      returnMessage = response.generateOkResponse("Password updated")
-      await signToken(res, user.email, newPassword);
+        const newPassword = req.body.password;
+        if (!newPassword) {
+            returnMessage =
+      response.generateResponseMessage("No new password specified under the 'passwprd'"
+      + ' field', 400);
+        } else {
+            user.password = newPassword;
+            user.save();
+            returnMessage = response.generateOkResponse('Password updated');
+            await signToken(res, user.email, newPassword);
 
+        }
     }
-  }
-  res.json(returnMessage);
+    res.json(returnMessage);
 });
 
-router.post('/addClient', async (req, res, next) => {
-  const client = req.body;
-  Client.create(client, (err) => {
-    if (!!err) {
-      res.json(response.generateResponseMessage('Error 400 - Bad Request- ' +
+router.post('/addClient', async(req, res, next) => {
+    const client = req.body;
+    Client.create(client, (err) => {
+        if (err) {
+            res.json(response.generateResponseMessage('Error 400 - Bad Request- ' +
       'Invalid syntax when trying to' +
       ' create client (see error)', 400, error = err));
-    } else {
-      res.json(response.generateOkResponse("Client added successfully"));
-    }
-  });
+        } else {
+            res.json(response.generateOkResponse('Client added successfully'));
+        }
+    });
 });
 
-router.get('/getAllClients', async (req, res, next) => {
-  try {
-    const allClients = await Client.find({});
-    res.json(response.generateOkResponse("All is well.", allClients));
-  } catch (err) {
-    res.json(response.generateInternalServerError(err));
-  }
+router.get('/getAllClients', async(req, res, next) => {
+    try {
+        const allClients = await Client.find({});
+        res.json(response.generateOkResponse('All is well.', allClients));
+    } catch (err) {
+        res.json(response.generateInternalServerError(err));
+    }
 });
 
 

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -132,9 +132,7 @@ router.post('/signup', function(req, res) {
                 return res.json(response);
             }
 
-            return res.json(response.generateResponseMessage('Internal server error', 500,
-                error = 'Error 500 - Internal Server Error - Line 114 in main route.'));
-
+            return res.json(response.generateResponseMessage('Internal server error', 500, 'Error 500 - Internal Server Error - Line 114 in main route.'));
         }
 
         // Account created. Redirect to login
@@ -276,8 +274,7 @@ router.post('/addClient', async(req, res, next) => {
     Client.create(client, (err) => {
         if (err) {
             res.json(response.generateResponseMessage('Error 400 - Bad Request- ' +
-      'Invalid syntax when trying to' +
-      ' create client (see error)', 400, error = err));
+            'Invalid syntax when trying to create client (see error)', 400, err));
         } else {
             res.json(response.generateOkResponse('Client added successfully'));
         }

--- a/backend/routes/transactions-router.js
+++ b/backend/routes/transactions-router.js
@@ -4,82 +4,82 @@ const mongoose = require('mongoose');
 const Transaction = require('../model/transaction.js');
 const UserModel = require('../model/user');
 const UserDB = mongoose.model('User', UserModel.__Schema);
-const { ShopItem, VolunteerItem } = require('../model/transactionItem.js')
+const { ShopItem, VolunteerItem } = require('../model/transactionItem.js');
 const response = require('../utilities/response.js');
 
-router.get('/client', async (req, res, next) => {
+router.get('/client', async(req, res, next) => {
     try {
         const allTransactionsByClient = await Transaction.find({
             clientId: req.query.id,
         });
-        const message = response.generateOkResponse("Success", allTransactionsByClient);
+        const message = response.generateOkResponse('Success', allTransactionsByClient);
         res.json(message);
     } catch (err) {
         res.json(response.generateInternalServerError(err));
     }
 });
 
-router.get('/authorizedUser', async (req, res, next) => {
+router.get('/authorizedUser', async(req, res, next) => {
     try {
         const allTransactionsByAuthorizer = await Transaction.find({
             authorizedUser: req.query.id
         });
-        const message = response.generateOkResponse("Success", allTransactionsByAuthorizer);
+        const message = response.generateOkResponse('Success', allTransactionsByAuthorizer);
         res.json(message);
     } catch (err) {
         res.json(response.generateInternalServerError(err));
     }
 });
 
-router.get('/getShopItems', async (req, res, next) => {
+router.get('/getShopItems', async(req, res, next) => {
     if (req.query.revisionNumber) {
         console.log(req.query.revisionNumber);
         try {
             const allItemsByVersion = await ShopItem.find({
                 revisionNumber: req.query.revisionNumber
             });
-            const message = response.generateOkResponse("Success", allItemsByVersion);
-            res.json(message)
+            const message = response.generateOkResponse('Success', allItemsByVersion);
+            res.json(message);
         } catch (err) {
             res.json(response.generateInternalServerError(err));
         }
     } else {
         try {
             let allItemsByMostRecentVersion = await ShopItem.getMostRecentRevision();
-            const message = response.generateOkResponse("Success", allItemsByMostRecentVersion);
-            res.json(message)
+            const message = response.generateOkResponse('Success', allItemsByMostRecentVersion);
+            res.json(message);
         } catch (err) {
             res.json(response.generateInternalServerError(err));
         }
     }
 });
 
-router.get('/getVolunteerItems', async (req, res, next) => {
+router.get('/getVolunteerItems', async(req, res, next) => {
     if (req.query.revisionNumber) {
         try {
             const allItemsByVersion = await VolunteerItem.find({
                 revisionNumber: req.query.revisionNumber
             });
-            const message = response.generateOkResponse("Success", allItemsByVersion);
-            res.json(message)
+            const message = response.generateOkResponse('Success', allItemsByVersion);
+            res.json(message);
         } catch (err) {
             res.json(response.generateInternalServerError(err));
         }
     } else {
         try {
             let allItemsByMostRecentVersion = await VolunteerItem.getMostRecentRevision();
-            const message = response.generateOkResponse("Success", 
-            allItemsByMostRecentVersion);
-            res.json(message)
+            const message = response.generateOkResponse('Success',
+                allItemsByMostRecentVersion);
+            res.json(message);
         } catch (err) {
             res.json(response.generateInternalServerError(err));
         }
     }
 });
 
-router.get('/getTransaction', async (req, res, next) => {
+router.get('/getTransaction', async(req, res, next) => {
     const { startDate, endDate, transactionType } = req.query;
-    
+
     let query = {};
     if (transactionType) {
         query.type = transactionType;
@@ -99,14 +99,14 @@ router.get('/getTransaction', async (req, res, next) => {
 
     try {
         const allTransactions = await Transaction.find(query);
-        const message = response.generateOkResponse("Success", allTransactions);
+        const message = response.generateOkResponse('Success', allTransactions);
         res.json(message);
     } catch (err) {
         res.json(response.generateInternalServerError(err));
     }
 });
 
-router.post('/updateItems', async (req, res, next) => {
+router.post('/updateItems', async(req, res, next) => {
     const { updatedItems, itemType } = req.body;
     for (let i = 0; i < updatedItems.length; i++) {
         const item = updatedItems[i];
@@ -123,7 +123,7 @@ router.post('/updateItems', async (req, res, next) => {
                 return;
             }
 
-            res.json(response.generateOkResponse("Success"));
+            res.json(response.generateOkResponse('Success'));
         });
     } else if (itemType === 'VOLUNTEER') {
         VolunteerItem.create(updatedItems, (err) => {
@@ -132,15 +132,15 @@ router.post('/updateItems', async (req, res, next) => {
                 return;
             }
 
-            res.json(response.generateOkResponse("Success"));
+            res.json(response.generateOkResponse('Success'));
         });
     } else {
-        res.json(response.generateInternalServerError("Invalid item type:" +
-        "should be either SHOP or VOLUNTEER."));
+        res.json(response.generateInternalServerError('Invalid item type:' +
+        'should be either SHOP or VOLUNTEER.'));
     }
 });
 
-router.post("/addTransaction", async (req, res, next) => {
+router.post('/addTransaction', async(req, res, next) => {
     const { transaction } = req.body;
     Transaction.create(transaction, (err) => {
         if (err) {
@@ -148,11 +148,11 @@ router.post("/addTransaction", async (req, res, next) => {
             return;
         }
 
-        res.json(response.generateOkResponse("Success"));
+        res.json(response.generateOkResponse('Success'));
     });
 });
 
-router.get("/getStats", async (req, res, next) => {
+router.get('/getStats', async(req, res, next) => {
     const userCount = await UserDB.getCount();
     const shopCount = (await Transaction.getShopItems()).length;
     const volunteerCount = (await Transaction.getVolunteerItems()).length;
@@ -160,8 +160,8 @@ router.get("/getStats", async (req, res, next) => {
         userCount,
         shopCount,
         volunteerCount
-    }
-    res.json(response.generateOkResponse("Statistics all good", output));
+    };
+    res.json(response.generateOkResponse('Statistics all good', output));
 });
 
 module.exports = router;

--- a/backend/routes/user-router.js
+++ b/backend/routes/user-router.js
@@ -11,14 +11,14 @@ const userModel = require('../model/user');
  */
 router.post('/setPermissionGroup',
     RESPONSE.generatePermissionsRoute(['promote']),
-    async (req, res) => {
+    async(req, res) => {
         const { userEmail, newGroup } = req.body;
         let output;
         if (PERMISSION_GROUPS_MAP[newGroup]) {
-            const queryResult = await userModel.updateOne({email: userEmail},  {permissionGroup: newGroup});
+            const queryResult = await userModel.updateOne({ email: userEmail },  { permissionGroup: newGroup });
             if (queryResult.n === 0) {
-                output = RESPONSE.generateParameterError({userEmail: `The inputed user of ${userEmail} `
-                        + `does not exist in the database`});
+                output = RESPONSE.generateParameterError({ userEmail: `The inputed user of ${userEmail} `
+                        + 'does not exist in the database' });
             } else {
                 if (queryResult.nModified === 0) {
                     output = RESPONSE.generateOkResponse(`${userEmail}'s group did not change. He or she was already ${newGroup}.`);
@@ -28,13 +28,13 @@ router.post('/setPermissionGroup',
             }
 
         } else {
-            output = RESPONSE.generateParameterError({newGroup: `The inputed group of ${newGroup} `
-                + `does not exist`});
+            output = RESPONSE.generateParameterError({ newGroup: `The inputed group of ${newGroup} `
+                + 'does not exist' });
         }
 
 
         res.json(output);
-});
+    });
 /**
  * Gets the user permissions for the inputted user @userEmail. Assumes current user if no inputted user email.
  * Requires 'user-access' permission if trying to access permissions other than the caller's own
@@ -50,32 +50,32 @@ router.post('/getUserPermissions',
         }
     },
     RESPONSE.generatePermissionsRoute(['user-access']),
-    async (req, res) => {
+    async(req, res) => {
         const { userEmail } = req.body;
         let output;
-        const targetUser = await userModel.findOne({email: userEmail});
+        const targetUser = await userModel.findOne({ email: userEmail });
         if (targetUser == null) {
-            output = RESPONSE.generateParameterError({userEmail: `The inputed user of ${userEmail} `
-                    + `does not exist in the database`});
+            output = RESPONSE.generateParameterError({ userEmail: `The inputed user of ${userEmail} `
+                    + 'does not exist in the database' });
         } else {
             output = RESPONSE.generateOkResponse(`${userEmail} permissions exist.`,
-                {permissionGroup: targetUser.permissionGroup, permissions: targetUser.getPermissions(),
-                userEmail});
+                { permissionGroup: targetUser.permissionGroup, permissions: targetUser.getPermissions(),
+                    userEmail });
         }
 
         res.json(output);
-});
+    });
 
 
 /**
  * Gets the current user's permission group and the user's permissions. The permissionGroup of the user calling the end point
  * Sends a response with that info
  */
-function getCurrentUserInfoAndSend (res, req, next) {
+function getCurrentUserInfoAndSend(res, req, next) {
     const user = res.locals.user;
     const permissionGroup = user.permissionGroup;
     const permissions = user.getPermissions();
-    res.json(RESPONSE.generateOkResponse('Current user\'s permissions', {permissionGroup, permissions, userEmail: user.email}));
+    res.json(RESPONSE.generateOkResponse('Current user\'s permissions', { permissionGroup, permissions, userEmail: user.email }));
 }
 
 module.exports = router;

--- a/backend/utilities/response.js
+++ b/backend/utilities/response.js
@@ -3,11 +3,11 @@ const OK_CODE = 200;
 
 /**
  * Generates error message and returns json object in appropriate format
- * @param {string} message 
- * @param {int} errorCode 
- * @param {string} error 
+ * @param {string} message
+ * @param {int} errorCode
+ * @param {string} error
  */
-function generateResponseMessage (message, errorCode, error = null,
+function generateResponseMessage(message, errorCode, error = null,
     additionalParameters = null) {
     let response = {
         message: message,
@@ -17,7 +17,7 @@ function generateResponseMessage (message, errorCode, error = null,
     if (errorCode != OK_CODE) {
         response.error = error;
     }
-    if (!!additionalParameters) {
+    if (additionalParameters) {
         response.body = additionalParameters;
     }
     return response;
@@ -25,11 +25,11 @@ function generateResponseMessage (message, errorCode, error = null,
 
 /**
  * Generates error message and returns json string in appropriate format
- * @param {string} message 
- * @param {int} errorCode 
- * @param {string} error 
+ * @param {string} message
+ * @param {int} errorCode
+ * @param {string} error
  */
-function responseString (message, errorCode, error = null,
+function responseString(message, errorCode, error = null,
     additionalParameters = null) {
     return JSON.stringify(generateResponseMessage(message, errorCode, error, additionalParameters));
 }
@@ -40,26 +40,26 @@ function responseString (message, errorCode, error = null,
  * @param {*} additionalParameters - any additional parameters for the message
  * body
  */
-function generateOkResponse (message, additionalParameters = null) {
+function generateOkResponse(message, additionalParameters = null) {
     return generateResponseMessage(message, OK_CODE, null, additionalParameters);
 }
 
 /**
 * Returns message body for when the user cannot be found
-* @param {string} user email 
+* @param {string} user email
 */
-function generateUserNotFoundError (email) {
+function generateUserNotFoundError(email) {
     return generateResponseMessage('User not found', 404, error = 'Error 404 - ' +
-    'Resource Not Found - A user could not be found with the associated email, ' 
+    'Resource Not Found - A user could not be found with the associated email, '
     + email);
 }
 
 /**
  * Generates error message
  */
-function generateTokenError () {
-    return generateResponseMessage('No token cookie provided', 401, 
-    error = 'Error 401 - Unauthorized - No login token  provided')
+function generateTokenError() {
+    return generateResponseMessage('No token cookie provided', 401,
+        error = 'Error 401 - Unauthorized - No login token  provided');
 }
 
 /**
@@ -69,14 +69,14 @@ function generateTokenError () {
  * @returns {Function} If the user calling the endpoint does not have the permissions, it will throw a permissions
  * error with the missing permissions. Otherwise, it will call next() (and move on to the next function in the endpoint)
  */
-function generatePermissionsRoute (requiredPermissions) {
-    return function (req, res, next) {
+function generatePermissionsRoute(requiredPermissions) {
+    return function(req, res, next) {
         const userMakingCall = res.locals.user;
         const missingPermissions = [];
         requiredPermissions.forEach((permission) => {
-           if (!userMakingCall.hasPermission(permission)) {
-               missingPermissions.push(permission);
-           }
+            if (!userMakingCall.hasPermission(permission)) {
+                missingPermissions.push(permission);
+            }
         });
 
         if (missingPermissions.length > 0) {
@@ -84,7 +84,7 @@ function generatePermissionsRoute (requiredPermissions) {
         } else {
             next();
         }
-    }
+    };
 }
 
 /**
@@ -92,31 +92,31 @@ function generatePermissionsRoute (requiredPermissions) {
  * @param userGroup - the user's group with the missing permissions
  * @param permissionsNeeded - an array of the missing permissionsf
  */
-function generatePermissionsError (userGroup, permissionsNeeded) {
+function generatePermissionsError(userGroup, permissionsNeeded) {
     return generateResponseMessage(`User of group ${userGroup} does not have the required permissions.`, 401,
-        error = 'Error 401 -  Does not have required permissions', {permissionsNeeded});
+        error = 'Error 401 -  Does not have required permissions', { permissionsNeeded });
 }
 
 /**
  *
  * @param invalidParametersMap - map of the parameter that is invalid and the reason/justification
  */
-function generateParameterError (invalidParametersMap) {
+function generateParameterError(invalidParametersMap) {
     return generateResponseMessage('The route was called with invalid parameters', 400,
-        error = `Error 400 - Invalid/Bad request because of bad parameters`, {invalidParameters: invalidParametersMap});
+        error = 'Error 400 - Invalid/Bad request because of bad parameters', { invalidParameters: invalidParametersMap });
 }
 
 /**
  * Generates internal server error
  * @param {Object} error - null by default. Object
  */
-function generateInternalServerError (error = null) {
+function generateInternalServerError(error = null) {
     const errorCode = 500;
-    const errorMessage = "Error 500 - Internal Server. Unknown." ;
+    const errorMessage = 'Error 500 - Internal Server. Unknown.';
 
-    const message = "Internal server error. Check console for details"
-    return generateResponseMessage(message, errorCode, errorMessage, 
-        !!error ? {error}: errorMessage);
+    const message = 'Internal server error. Check console for details';
+    return generateResponseMessage(message, errorCode, errorMessage,
+        error ? { error }: errorMessage);
 }
 module.exports = {
     OK_CODE: OK_CODE,
@@ -129,4 +129,4 @@ module.exports = {
     generatePermissionsError,
     generateParameterError,
     responseString
-}
+};

--- a/backend/utilities/response.js
+++ b/backend/utilities/response.js
@@ -14,7 +14,7 @@ function generateResponseMessage(message, errorCode, error = null,
         errorCode: errorCode
     };
 
-    if (errorCode != OK_CODE) {
+    if (errorCode !== OK_CODE) {
         response.error = error;
     }
     if (additionalParameters) {
@@ -49,7 +49,7 @@ function generateOkResponse(message, additionalParameters = null) {
 * @param {string} user email
 */
 function generateUserNotFoundError(email) {
-    return generateResponseMessage('User not found', 404, error = 'Error 404 - ' +
+    return generateResponseMessage('User not found', 404, 'Error 404 - ' +
     'Resource Not Found - A user could not be found with the associated email, '
     + email);
 }
@@ -59,7 +59,7 @@ function generateUserNotFoundError(email) {
  */
 function generateTokenError() {
     return generateResponseMessage('No token cookie provided', 401,
-        error = 'Error 401 - Unauthorized - No login token  provided');
+        'Error 401 - Unauthorized - No login token  provided');
 }
 
 /**
@@ -94,7 +94,7 @@ function generatePermissionsRoute(requiredPermissions) {
  */
 function generatePermissionsError(userGroup, permissionsNeeded) {
     return generateResponseMessage(`User of group ${userGroup} does not have the required permissions.`, 401,
-        error = 'Error 401 -  Does not have required permissions', { permissionsNeeded });
+        'Error 401 -  Does not have required permissions', { permissionsNeeded });
 }
 
 /**
@@ -103,7 +103,7 @@ function generatePermissionsError(userGroup, permissionsNeeded) {
  */
 function generateParameterError(invalidParametersMap) {
     return generateResponseMessage('The route was called with invalid parameters', 400,
-        error = 'Error 400 - Invalid/Bad request because of bad parameters', { invalidParameters: invalidParametersMap });
+        'Error 400 - Invalid/Bad request because of bad parameters', { invalidParameters: invalidParametersMap });
 }
 
 /**

--- a/config.js
+++ b/config.js
@@ -2,8 +2,8 @@ require('dotenv').config();
 let config = {};
 
 config.port = 5000;
-config.db_path = "test";
+config.db_path = 'test';
 config.db_url = `mongodb+srv://${process.env.DB_USER}:${process.env.DB_PASS}@ircdb-adim8.mongodb.net/test?retryWrites=true`;
-config.JWT_SECRET = "KLD24Fj#U_RI@JRIJi5!jdf20rk3jlk4?jfa";
+config.JWT_SECRET = 'KLD24Fj#U_RI@JRIJi5!jdf20rk3jlk4?jfa';
 
 module.exports = config;

--- a/frontend-material/.eslintrc.yml
+++ b/frontend-material/.eslintrc.yml
@@ -1,0 +1,24 @@
+env:
+  browser: true
+  es6: true
+  node: true
+extends:
+  - 'plugin:react/recommended'
+parser: babel-eslint
+parserOptions:
+  ecmaFeatures:
+    jsx: true
+  sourceType: module
+plugins:
+  - react
+settings:
+  react:
+    version: '16.5'
+rules:
+  indent:
+    - warn
+    - 2
+  react/prop-types:
+    - off
+  no-useless-escape:
+    - off

--- a/frontend-material/config/webpack.common.js
+++ b/frontend-material/config/webpack.common.js
@@ -1,12 +1,12 @@
-const path = require("path");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const webpack = require("webpack");
-const devMode = process.env.NODE_ENV !== "production";
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
+const devMode = process.env.NODE_ENV !== 'production';
 
 module.exports = {
   resolve: {
-    modules: [path.resolve(__dirname, "../src"), "node_modules"]
+    modules: [path.resolve(__dirname, '../src'), 'node_modules']
   },
   module: {
     rules: [
@@ -14,28 +14,28 @@ module.exports = {
         test: /\.js$/,
         exclude: /node_modules/,
         use: {
-          loader: "babel-loader"
+          loader: 'babel-loader'
         }
       },
       {
         test: /\.(sa|sc|c)ss$/,
         use: [
-          devMode ? "style-loader" : MiniCssExtractPlugin.loader,
-          "css-loader",
-          "postcss-loader",
-          "sass-loader"
+          devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+          'css-loader',
+          'postcss-loader',
+          'sass-loader'
         ]
       },
       {
         test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2|otf|json)$/,
         use: [
           {
-            loader: "url-loader",
+            loader: 'url-loader',
             options: {
-              fallback: "file-loader",
+              fallback: 'file-loader',
               limit: 8192,
-              context: path.resolve(__dirname, "../src"),
-              name: "[path][name].[ext]"
+              context: path.resolve(__dirname, '../src'),
+              name: '[path][name].[ext]'
             }
           }
         ]
@@ -44,12 +44,12 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: "./src/index.html",
-      filename: "index.html"
+      template: './src/index.html',
+      filename: 'index.html'
     }),
     new MiniCssExtractPlugin({
-      filename: devMode ? "[name].css" : "[name].[hash].css",
-      chunkFilename: devMode ? "[id].css" : "[id].[hash].css"
+      filename: devMode ? '[name].css' : '[name].[hash].css',
+      chunkFilename: devMode ? '[id].css' : '[id].[hash].css'
     })
   ]
 };

--- a/frontend-material/config/webpack.dev.js
+++ b/frontend-material/config/webpack.dev.js
@@ -1,15 +1,15 @@
-const path = require("path");
-const webpack = require("webpack");
-const merge = require("webpack-merge");
+const path = require('path');
+const webpack = require('webpack');
+const merge = require('webpack-merge');
 
-const webpackCommon = require("./webpack.common");
+const webpackCommon = require('./webpack.common');
 
 module.exports = merge.smart(webpackCommon, {
-  mode: "development",
+  mode: 'development',
   output: {
-    publicPath: "/", // deploy on server with /app/ folder name
-    filename: "[name].bundle.js",
-    path: path.resolve(__dirname, "../docs")
+    publicPath: '/', // deploy on server with /app/ folder name
+    filename: '[name].bundle.js',
+    path: path.resolve(__dirname, '../docs')
   },
   devServer: {
     hot: true,
@@ -17,10 +17,10 @@ module.exports = merge.smart(webpackCommon, {
     historyApiFallback: true,
     overlay: true,
     port: 8015,
-    contentBase: path.join(__dirname, "docs"),
-    host: "localhost",
-    publicPath: "/"
+    contentBase: path.join(__dirname, 'docs'),
+    host: 'localhost',
+    publicPath: '/'
   },
-  devtool: "cheap-eval-source-map",
+  devtool: 'cheap-eval-source-map',
   plugins: [new webpack.HotModuleReplacementPlugin()]
 });

--- a/frontend-material/config/webpack.prod.js
+++ b/frontend-material/config/webpack.prod.js
@@ -1,23 +1,23 @@
-const path = require("path");
-const merge = require("webpack-merge");
-const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
-const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
-const CleanWbepackPlugin = require("clean-webpack-plugin");
+const path = require('path');
+const merge = require('webpack-merge');
+const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const CleanWbepackPlugin = require('clean-webpack-plugin');
 
-const webpackCommon = require("./webpack.common");
+const webpackCommon = require('./webpack.common');
 
-const pathsToClean = ["docs"];
+const pathsToClean = ['docs'];
 const cleanOptions = {
-  root: path.resolve(__dirname, "../")
+  root: path.resolve(__dirname, '../')
 };
 
 module.exports = merge.smart(webpackCommon, {
   output: {
-    filename: "main.[chunkhash].js",
-    path: path.resolve(__dirname, "../docs"),
-    publicPath: "/"
+    filename: 'main.[chunkhash].js',
+    path: path.resolve(__dirname, '../docs'),
+    publicPath: '/'
   },
-  mode: "production",
+  mode: 'production',
   optimization: {
     minimizer: [
       new UglifyJsPlugin({
@@ -34,8 +34,8 @@ module.exports = merge.smart(webpackCommon, {
         default: false,
         commons: {
           test: /[\\/]node_modules[\\/]/,
-          name: "vendor_app",
-          chunks: "all",
+          name: 'vendor_app',
+          chunks: 'all',
           minChunks: 2
         }
       }

--- a/frontend-material/src/empty-states/EmptyCart.js
+++ b/frontend-material/src/empty-states/EmptyCart.js
@@ -1,5 +1,5 @@
-import React from "react";
-import empty_cart from "assets/img/empty-cart.png"
+import React from 'react';
+import empty_cart from 'assets/img/empty-cart.png';
 
 const EmptyCart = props => {
   return (

--- a/frontend-material/src/empty-states/NoResults.js
+++ b/frontend-material/src/empty-states/NoResults.js
@@ -1,5 +1,5 @@
-import React from "react";
-import tree from "assets/img/bare-tree.png"
+import React from 'react';
+import tree from 'assets/img/bare-tree.png';
 
 
 const NoResults = () => {

--- a/frontend-material/src/index.js
+++ b/frontend-material/src/index.js
@@ -1,11 +1,11 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import { createBrowserHistory } from "history";
-import { Router, Route, Switch } from "react-router-dom";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { createBrowserHistory } from 'history';
+import { Router, Route, Switch } from 'react-router-dom';
 
-import "assets/css/material-dashboard-react.css?v=1.5.0";
+import 'assets/css/material-dashboard-react.css?v=1.5.0';
 
-import indexRoutes from "routes/index.jsx";
+import indexRoutes from 'routes/index.jsx';
 
 const hist = createBrowserHistory();
 
@@ -17,5 +17,5 @@ ReactDOM.render(
       })}
     </Switch>
   </Router>,
-  document.getElementById("root")
+  document.getElementById('root')
 );

--- a/frontend-material/src/loaders/Product.js
+++ b/frontend-material/src/loaders/Product.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 const LoadingProduct = () => {
   return (

--- a/frontend-material/src/loaders/Products.js
+++ b/frontend-material/src/loaders/Products.js
@@ -1,5 +1,5 @@
-import React, { Component } from "react";
-import Product from "./Product";
+import React, { Component } from 'react';
+import Product from './Product';
 
 class LoadingProducts extends Component {
   render() {

--- a/frontend-material/src/routes/dashboard.jsx
+++ b/frontend-material/src/routes/dashboard.jsx
@@ -1,99 +1,99 @@
 // @material-ui/icons
-import Dashboard from "@material-ui/icons/Dashboard";
-import Person from "@material-ui/icons/Person";
-import AccountBox from "@material-ui/icons/AccountBox";
-import BubbleChart from "@material-ui/icons/BubbleChart";
-import AccessTime from "@material-ui/icons/AccessTime";
-import ShoppingCart from "@material-ui/icons/ShoppingCart";
-import List from "@material-ui/icons/List";
+import Dashboard from '@material-ui/icons/Dashboard';
+import Person from '@material-ui/icons/Person';
+import AccountBox from '@material-ui/icons/AccountBox';
+import BubbleChart from '@material-ui/icons/BubbleChart';
+import AccessTime from '@material-ui/icons/AccessTime';
+import ShoppingCart from '@material-ui/icons/ShoppingCart';
+import List from '@material-ui/icons/List';
 
 // core components/views
-import LandingPage from "views/LandingPage/LandingPage.jsx";
-import UserProfile from "views/UserProfile/UserProfile.jsx";
-import ShopList from "views/ShopList/ShopList.jsx";
-import TimeList from "views/TimeList/TimeList.jsx";
-import SignUp from "views/SignUp/SignUp.jsx";
+import LandingPage from 'views/LandingPage/LandingPage.jsx';
+import UserProfile from 'views/UserProfile/UserProfile.jsx';
+import ShopList from 'views/ShopList/ShopList.jsx';
+import TimeList from 'views/TimeList/TimeList.jsx';
+import SignUp from 'views/SignUp/SignUp.jsx';
 
 // admin views
-import DashboardPage from "views/Dashboard/Dashboard.jsx";
-import ShopModify from "views/ShopModify/ShopModify.jsx";
-import TimeModify from "views/TimeModify/TimeModify.jsx";
-import UserModify from "views/UserModify/UserModify.jsx";
-import Login from "views/Login/Login.jsx";
+import DashboardPage from 'views/Dashboard/Dashboard.jsx';
+import ShopModify from 'views/ShopModify/ShopModify.jsx';
+import TimeModify from 'views/TimeModify/TimeModify.jsx';
+import UserModify from 'views/UserModify/UserModify.jsx';
+import Login from 'views/Login/Login.jsx';
 
 const dashboardRoutes = [
   {
-    path: "/login",
-    sidebarName: "Login",
-    navbarName: "Login",
+    path: '/login',
+    sidebarName: 'Login',
+    navbarName: 'Login',
     icon: BubbleChart,
     component: Login
   },
   {
-    path: "/landing",
-    sidebarName: "Landing",
-    navbarName: "Landing Page",
+    path: '/landing',
+    sidebarName: 'Landing',
+    navbarName: 'Landing Page',
     icon: BubbleChart,
     component: LandingPage
   },
   {
-    path: "/signup",
-    sidebarName: "Sign Up",
-    navbarName: "Sign Up",
+    path: '/signup',
+    sidebarName: 'Sign Up',
+    navbarName: 'Sign Up',
     icon: Person,
     component: SignUp
   },
   {
-    path: "/user",
-    sidebarName: "User Profile",
-    navbarName: "Profile",
+    path: '/user',
+    sidebarName: 'User Profile',
+    navbarName: 'Profile',
     icon: Person,
     component: UserProfile
   },
   {
-    path: "/shop",
-    sidebarName: "Storefront",
-    navbarName: "Product Storefront",
+    path: '/shop',
+    sidebarName: 'Storefront',
+    navbarName: 'Product Storefront',
     icon: ShoppingCart,
     component: ShopList
   },
   {
-    path: "/time",
-    sidebarName: "Volunteer Time",
-    navbarName: "Volunteer Time",
+    path: '/time',
+    sidebarName: 'Volunteer Time',
+    navbarName: 'Volunteer Time',
     icon: AccessTime,
     component: TimeList
   },
   // Admin Features
   {
-    path: "/dashboard",
-    sidebarName: "Reporting",
-    navbarName: "Reports Dashboard",
+    path: '/dashboard',
+    sidebarName: 'Reporting',
+    navbarName: 'Reports Dashboard',
     icon: Dashboard,
     component: DashboardPage
   },
   {
-    path: "/modifyShop",
-    sidebarName: "Modify Shop",
-    navbarName: "Modify Shop",
+    path: '/modifyShop',
+    sidebarName: 'Modify Shop',
+    navbarName: 'Modify Shop',
     icon: List,
     component: ShopModify
   },
   {
-    path: "/modifyTime",
-    sidebarName: "Modify Time",
-    navbarName: "Modify Time",
+    path: '/modifyTime',
+    sidebarName: 'Modify Time',
+    navbarName: 'Modify Time',
     icon: List,
     component: TimeModify
   },
   {
-    path: "/modifyUser",
-    sidebarName: "Edit Users",
-    navbarName: "Edit Users",
+    path: '/modifyUser',
+    sidebarName: 'Edit Users',
+    navbarName: 'Edit Users',
     icon: AccountBox,
     component: UserModify
   },
-  { redirect: true, path: "/", to: "/login", navbarName: "Redirect" }
+  { redirect: true, path: '/', to: '/login', navbarName: 'Redirect' }
 ];
 
 export default dashboardRoutes;

--- a/frontend-material/src/routes/index.jsx
+++ b/frontend-material/src/routes/index.jsx
@@ -1,5 +1,5 @@
-import Dashboard from "layouts/Dashboard/Dashboard.jsx";
+import Dashboard from 'layouts/Dashboard/Dashboard.jsx';
 
-const indexRoutes = [{ path: "/", component: Dashboard }];
+const indexRoutes = [{ path: '/', component: Dashboard }];
 
 export default indexRoutes;

--- a/frontend-material/src/variables/charts.jsx
+++ b/frontend-material/src/variables/charts.jsx
@@ -1,7 +1,7 @@
 // ##############################
 // // // javascript library for creating charts
 // #############################
-let Chartist = require("chartist");
+let Chartist = require('chartist');
 
 // ##############################
 // // // variables used to create animation on charts
@@ -17,7 +17,7 @@ let delays2 = 80,
 
 const dailySalesChart = {
   data: {
-    labels: ["M", "T", "W", "T", "F", "S", "S"],
+    labels: ['M', 'T', 'W', 'T', 'F', 'S', 'S'],
     series: [[12, 17, 7, 17, 23, 18, 38]]
   },
   options: {
@@ -36,7 +36,7 @@ const dailySalesChart = {
   // for animation
   animation: {
     draw: function(data) {
-      if (data.type === "line" || data.type === "area") {
+      if (data.type === 'line' || data.type === 'area') {
         data.element.animate({
           d: {
             begin: 600,
@@ -50,14 +50,14 @@ const dailySalesChart = {
             easing: Chartist.Svg.Easing.easeOutQuint
           }
         });
-      } else if (data.type === "point") {
+      } else if (data.type === 'point') {
         data.element.animate({
           opacity: {
             begin: (data.index + 1) * delays,
             dur: durations,
             from: 0,
             to: 1,
-            easing: "ease"
+            easing: 'ease'
           }
         });
       }
@@ -72,18 +72,18 @@ const dailySalesChart = {
 const emailsSubscriptionChart = {
   data: {
     labels: [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "Mai",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sep",
-      "Oct",
-      "Nov",
-      "Dec"
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'Mai',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec'
     ],
     series: [[542, 443, 320, 780, 553, 453, 326, 434, 568, 610, 756, 895]]
   },
@@ -102,7 +102,7 @@ const emailsSubscriptionChart = {
   },
   responsiveOptions: [
     [
-      "screen and (max-width: 640px)",
+      'screen and (max-width: 640px)',
       {
         seriesBarDistance: 5,
         axisX: {
@@ -115,14 +115,14 @@ const emailsSubscriptionChart = {
   ],
   animation: {
     draw: function(data) {
-      if (data.type === "bar") {
+      if (data.type === 'bar') {
         data.element.animate({
           opacity: {
             begin: (data.index + 1) * delays2,
             dur: durations2,
             from: 0,
             to: 1,
-            easing: "ease"
+            easing: 'ease'
           }
         });
       }
@@ -136,7 +136,7 @@ const emailsSubscriptionChart = {
 
 const completedTasksChart = {
   data: {
-    labels: ["12am", "3pm", "6pm", "9pm", "12pm", "3am", "6am", "9am"],
+    labels: ['12am', '3pm', '6pm', '9pm', '12pm', '3am', '6am', '9am'],
     series: [[230, 750, 450, 300, 280, 240, 200, 190]]
   },
   options: {
@@ -154,7 +154,7 @@ const completedTasksChart = {
   },
   animation: {
     draw: function(data) {
-      if (data.type === "line" || data.type === "area") {
+      if (data.type === 'line' || data.type === 'area') {
         data.element.animate({
           d: {
             begin: 600,
@@ -168,14 +168,14 @@ const completedTasksChart = {
             easing: Chartist.Svg.Easing.easeOutQuint
           }
         });
-      } else if (data.type === "point") {
+      } else if (data.type === 'point') {
         data.element.animate({
           opacity: {
             begin: (data.index + 1) * delays,
             dur: durations,
             from: 0,
             to: 1,
-            easing: "ease"
+            easing: 'ease'
           }
         });
       }

--- a/frontend-material/src/variables/general.jsx
+++ b/frontend-material/src/variables/general.jsx
@@ -4,17 +4,17 @@
 
 let bugs = [
   'Sign contract for "What are conference organizers afraid of?"',
-  "Lines From Great Russian Literature? Or E-mails From My Boss?",
-  "Flooded: One year later, assessing what was lost and what was found when a ravaging rain swept through metro Detroit",
-  "Create 4 Invisible User Experiences you Never Knew About"
+  'Lines From Great Russian Literature? Or E-mails From My Boss?',
+  'Flooded: One year later, assessing what was lost and what was found when a ravaging rain swept through metro Detroit',
+  'Create 4 Invisible User Experiences you Never Knew About'
 ];
 let website = [
-  "Flooded: One year later, assessing what was lost and what was found when a ravaging rain swept through metro Detroit",
+  'Flooded: One year later, assessing what was lost and what was found when a ravaging rain swept through metro Detroit',
   'Sign contract for "What are conference organizers afraid of?"'
 ];
 let server = [
-  "Lines From Great Russian Literature? Or E-mails From My Boss?",
-  "Flooded: One year later, assessing what was lost and what was found when a ravaging rain swept through metro Detroit",
+  'Lines From Great Russian Literature? Or E-mails From My Boss?',
+  'Flooded: One year later, assessing what was lost and what was found when a ravaging rain swept through metro Detroit',
   'Sign contract for "What are conference organizers afraid of?"'
 ];
 

--- a/frontend-material/src/views/Dashboard/Dashboard.jsx
+++ b/frontend-material/src/views/Dashboard/Dashboard.jsx
@@ -1,36 +1,36 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 // @material-ui/core
-import withStyles from "@material-ui/core/styles/withStyles";
-import Icon from "@material-ui/core/Icon";
+import withStyles from '@material-ui/core/styles/withStyles';
+import Icon from '@material-ui/core/Icon';
 // @material-ui/icons
-import Store from "@material-ui/icons/Store";
-import DateRange from "@material-ui/icons/DateRange";
-import Accessibility from "@material-ui/icons/Accessibility";
+import Store from '@material-ui/icons/Store';
+import DateRange from '@material-ui/icons/DateRange';
+import Accessibility from '@material-ui/icons/Accessibility';
 // core components
-import GridItem from "components/Grid/GridItem.jsx";
-import GridContainer from "components/Grid/GridContainer.jsx";
-import CustomTable from "components/Table/Table.jsx";
+import GridItem from 'components/Grid/GridItem.jsx';
+import GridContainer from 'components/Grid/GridContainer.jsx';
+import CustomTable from 'components/Table/Table.jsx';
 
-import Card from "components/Card/Card.jsx";
-import CardHeader from "components/Card/CardHeader.jsx";
-import CardIcon from "components/Card/CardIcon.jsx";
+import Card from 'components/Card/Card.jsx';
+import CardHeader from 'components/Card/CardHeader.jsx';
+import CardIcon from 'components/Card/CardIcon.jsx';
 // import CardBody from "components/Card/CardBody.jsx";
-import CardFooter from "components/Card/CardFooter.jsx";
+import CardFooter from 'components/Card/CardFooter.jsx';
 
-//IRC added components
-import Button from "components/CustomButtons/Button.jsx";
+// IRC added components
+import Button from 'components/CustomButtons/Button.jsx';
 import Input from '@material-ui/core/Input';
-import {callBackendAPI} from "components/CallBackendApi";
+import { callBackendAPI } from 'components/CallBackendApi';
 
-import RadioGroup from '@material-ui/core/RadioGroup'
-import Radio from '@material-ui/core/Radio'
-import FormControl from '@material-ui/core/FormControl'
-import FormControlLabel from '@material-ui/core/FormControlLabel'
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Radio from '@material-ui/core/Radio';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
 
-import dashboardStyle from "assets/jss/material-dashboard-react/views/dashboardStyle.jsx";
+import dashboardStyle from 'assets/jss/material-dashboard-react/views/dashboardStyle.jsx';
 
 class Dashboard extends React.Component {
   state = {
@@ -38,10 +38,10 @@ class Dashboard extends React.Component {
     shopCount: 0,
     userCount: 0,
     volCount: 0,
-    from: "",
-    to: "",
+    from: '',
+    to: '',
     table: [],
-    type: "SHOP",
+    type: 'SHOP',
     clients: []
   };
   handleChange = (event, value) => {
@@ -62,23 +62,23 @@ class Dashboard extends React.Component {
         shopCount: response.shopCount,
         userCount: response.userCount,
         volCount: response.volunteerCount
-      })
-    })
+      });
+    });
     callBackendAPI('/api/getAllClients', 'get').then(response => {
       this.setState({
         clients: response
-      })
+      });
       console.log(this.state.clients);
     });
   }
 
-  //This function creates the table
+  // This function creates the table
   generateReport() {
     callBackendAPI('/api/transactions/getTransaction?transactionType='+this.state.type+'&startDate='+this.state.from+'&endDate='+this.state.to, 'get').then(response => {
       this.setState({
         table: []
-      })
-      if (this.state.type === "VOLUNTEER") {
+      });
+      if (this.state.type === 'VOLUNTEER') {
         for (let i = 0; i < response.length; i++) {
           for (let j = 0; j < response[i].volunteerItems.length; j++) {
             let table = this.state.table.slice();
@@ -95,7 +95,7 @@ class Dashboard extends React.Component {
             table.push([response[i].volunteerItems[j].item.name, response[i].volunteerItems[j].count, alienNumber, response[i].volunteerItems[j].item.price*response[i].volunteerItems[j].count]);
             this.setState({
               table: table
-            })
+            });
           }
         }
       } else {
@@ -115,33 +115,33 @@ class Dashboard extends React.Component {
             table.push([response[i].shopItems[j].item.name, response[i].shopItems[j].count, alienNumber, response[i].shopItems[j].item.price*response[i].shopItems[j].count]);
             this.setState({
               table: table
-            })
+            });
           }
         }
       }
       this.setState({
         isShown: true
-      })
+      });
     });
   }
 
-  //Return the data for the table
+  // Return the data for the table
   generateTableData() {
     console.log(this.state.table);
     return this.state.table;
   }
 
-  //Return the headers for the table
+  // Return the headers for the table
   generateTableHead() {
     return ['Item', 'Count', 'ClientId', 'Total Price'];
   }
 
-  //Download a csv file to Users
+  // Download a csv file to Users
   print() {
     let divToPrint = document.getElementsByClassName('outer')[0];
     console.log(divToPrint);
     divToPrint.childNodes[0].removeChild(divToPrint.childNodes[0].childNodes[0]);
-    let newWin = window.open("");
+    let newWin = window.open('');
     newWin.document.write(divToPrint.outerHTML);
     newWin.print();
     newWin.close();
@@ -150,13 +150,13 @@ class Dashboard extends React.Component {
   handleFromChange(event) {
     this.setState({
       from: event.target.value
-    })
+    });
   }
 
   handleToChange(event) {
     this.setState({
       to: event.target.value
-    })
+    });
   }
 
   render() {
@@ -228,34 +228,34 @@ class Dashboard extends React.Component {
           </GridItem>
         </GridContainer>
         <div>
-            <FormControl component="fieldset">
-                <RadioGroup
-                    aria-label="Type"
-                    name="type"
-                    value={this.state.type}
-                    onChange={this.handleTypeChange}
-                >
-                    <FormControlLabel value="SHOP" control={<Radio />} label="Shop" />
-                    <FormControlLabel value="VOLUNTEER" control={<Radio />} label="Volunteer" />
+          <FormControl component="fieldset">
+            <RadioGroup
+              aria-label="Type"
+              name="type"
+              value={this.state.type}
+              onChange={this.handleTypeChange}
+            >
+              <FormControlLabel value="SHOP" control={<Radio />} label="Shop" />
+              <FormControlLabel value="VOLUNTEER" control={<Radio />} label="Volunteer" />
 
-                </RadioGroup>
-            </FormControl>
+            </RadioGroup>
+          </FormControl>
         </div>
 
         <div className="outer">
-        {this.state.isShown &&
+          {this.state.isShown &&
           <div className="outerTable">
             <Button type="button" color="info" onClick = {() => this.print()}>
               Print
             </Button>
             <CustomTable
-            className = "printableTable"
-            tableHeaderColor="primary"
-            tableHead={this.generateTableHead()}
-            tableData={this.generateTableData()}
+              className = "printableTable"
+              tableHeaderColor="primary"
+              tableHead={this.generateTableHead()}
+              tableData={this.generateTableData()}
             />
           </div>
-        }
+          }
         </div>
 
       </div>

--- a/frontend-material/src/views/LandingPage/LandingPage.jsx
+++ b/frontend-material/src/views/LandingPage/LandingPage.jsx
@@ -1,44 +1,44 @@
-import React from "react";
-import { Redirect } from "react-router-dom";
-import PropTypes from "prop-types";
-import {callBackendAPI} from "components/CallBackendApi";
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { callBackendAPI } from 'components/CallBackendApi';
 
 // @material-ui/core
-import withStyles from "@material-ui/core/styles/withStyles";
+import withStyles from '@material-ui/core/styles/withStyles';
 
-import Card from "components/Card/Card.jsx";
-import CardHeader from "components/Card/CardHeader.jsx";
+import Card from 'components/Card/Card.jsx';
+import CardHeader from 'components/Card/CardHeader.jsx';
 
-import CardBody from "components/Card/CardBody.jsx";
-import Button from "components/CustomButtons/Button.jsx";
+import CardBody from 'components/Card/CardBody.jsx';
+import Button from 'components/CustomButtons/Button.jsx';
 
 import TextField from '@material-ui/core/TextField';
 
-import ErrorDialog from "components/ErrorDialog";
+import ErrorDialog from 'components/ErrorDialog';
 
 
-import dashboardStyle from "assets/jss/material-dashboard-react/views/dashboardStyle.jsx";
+import dashboardStyle from 'assets/jss/material-dashboard-react/views/dashboardStyle.jsx';
 
 class LandingPage extends React.Component {
   constructor() {
-    super()
+    super();
     this.state = {
       value: 0,
       open: false,
-      message: "",
-      fname: "",
-      lname: "",
+      message: '',
+      fname: '',
+      lname: '',
       isNotLoggedIn: false,
-      username: "",
-      password: "",
+      username: '',
+      password: '',
       redirect: false
-    }
+    };
     this.handleClose = this.handleClose.bind(this);
   }
 
   componentWillMount() {
     callBackendAPI('/api/verify', 'post', {}).then(response => {
-      if (response.error === "Error 401 - Unauthorized - No login token  provided") {
+      if (response.error === 'Error 401 - Unauthorized - No login token  provided') {
         this.setState({
           isNotLoggedIn: true
         });
@@ -47,7 +47,7 @@ class LandingPage extends React.Component {
           username: response.user.email,
           fname: response.user.firstName,
           lname: response.user.lastName
-        })
+        });
       }
     });
   }
@@ -59,7 +59,7 @@ class LandingPage extends React.Component {
   }
 
   handleLogin() {
-    callBackendAPI('/api/login','post', {
+    callBackendAPI('/api/login', 'post', {
       email: this.state.username,
       password: this.state.password
     }).then(response => {
@@ -71,9 +71,9 @@ class LandingPage extends React.Component {
       } else {
         this.setState({
           redirect: response.urlRedirect
-        })
+        });
       }
-    })
+    });
   }
 
   handleSignup() {
@@ -89,9 +89,9 @@ class LandingPage extends React.Component {
       } else {
         this.setState({
           redirect: response.urlRedirect
-        })
+        });
       }
-    })
+    });
   }
 
   handleChange = (event, value) => {
@@ -112,7 +112,7 @@ class LandingPage extends React.Component {
       <div>
         {!this.state.isNotLoggedIn &&
           <center>
-            <Card style={{ width: "60%" }}>
+            <Card style={{ width: '60%' }}>
               <CardHeader color="primary">
                 <h4 className={classes.cardTitleWhite}><center> Welcome, {this.state.fname}. </center></h4>
               </CardHeader>
@@ -126,9 +126,9 @@ class LandingPage extends React.Component {
           {this.state.isNotLoggedIn &&
             <center>
               <form onSubmit={e => { e.preventDefault(); this.handleLogin(); }}>
-                <Card style={{ width: "20rem" }}>
+                <Card style={{ width: '20rem' }}>
                   <CardBody>
-                    <CardHeader style={{ width: "10rem", bottom:"1rem" }} color="info">
+                    <CardHeader style={{ width: '10rem', bottom: '1rem' }} color="info">
                       <h4><center> Login/Signup </center></h4>
                     </CardHeader>
                     <TextField
@@ -139,13 +139,13 @@ class LandingPage extends React.Component {
                     <TextField
                       margin="normal"
                       label="Password"
-                      inputProps={{type: "password"}}
+                      inputProps={{ type: 'password' }}
                       onChange={e => this.setState({ password: e.target.value })}
                     />
                   </CardBody>
                   <CardBody>
                     <Button
-                      style={{ width: "5rem", right:"1rem" }}
+                      style={{ width: '5rem', right: '1rem' }}
                       color="success"
                       round={true}
                       type="submit"
@@ -153,7 +153,7 @@ class LandingPage extends React.Component {
                       Login
                     </Button>
                     <Button
-                      style={{ width:"5rem", left:"1rem" }}
+                      style={{ width: '5rem', left: '1rem' }}
                       color="success"
                       round={true}
                       onClick={() => this.handleSignup()}
@@ -168,13 +168,13 @@ class LandingPage extends React.Component {
         </div>
         {!this.state.isNotLoggedIn &&
           <center>
-          <Card style={{ width: "20rem" }}>
-            <CardBody>
-              <center>
-                <Button color="danger"> Log out </Button>
-              </center>
-            </CardBody>
-          </Card>
+            <Card style={{ width: '20rem' }}>
+              <CardBody>
+                <center>
+                  <Button color="danger"> Log out </Button>
+                </center>
+              </CardBody>
+            </Card>
           </center>
         }
         <ErrorDialog

--- a/frontend-material/src/views/Login/Login.jsx
+++ b/frontend-material/src/views/Login/Login.jsx
@@ -93,7 +93,7 @@ class Login extends React.Component {
                 </div>
 
                 <div className="small-space-top">
-                  <span>Don't have an account? &nbsp;</span>
+                  <span>Don’t have an account? &nbsp;</span>
                   <Link to="/signup" className="link">
                     Sign up here.
                   </Link>

--- a/frontend-material/src/views/Login/Login.jsx
+++ b/frontend-material/src/views/Login/Login.jsx
@@ -1,27 +1,27 @@
-import React from "react";
-import "assets/css/style.css";
+import React from 'react';
+import 'assets/css/style.css';
 
-import Card from "components/Card/Card.jsx";
-import CardBody from "components/Card/CardBody.jsx";
-import CardHeader from "components/Card/CardHeader.jsx";
-import Button from "components/CustomButtons/Button.jsx";
-import CustomInput from "components/CustomInput/CustomInput.jsx";
+import Card from 'components/Card/Card.jsx';
+import CardBody from 'components/Card/CardBody.jsx';
+import CardHeader from 'components/Card/CardHeader.jsx';
+import Button from 'components/CustomButtons/Button.jsx';
+import CustomInput from 'components/CustomInput/CustomInput.jsx';
 
-import {Link} from "react-router-dom";
-import {callBackendAPI} from "components/CallBackendApi";
-import withStyles from "@material-ui/core/styles/withStyles";
-import dashboardStyle from "assets/jss/material-dashboard-react/views/dashboardStyle.jsx";
+import { Link } from 'react-router-dom';
+import { callBackendAPI } from 'components/CallBackendApi';
+import withStyles from '@material-ui/core/styles/withStyles';
+import dashboardStyle from 'assets/jss/material-dashboard-react/views/dashboardStyle.jsx';
 
 class Login extends React.Component {
   constructor() {
     super();
     this.state = {
-      email: "",
-      password: "",
+      email: '',
+      password: '',
       emailError: false,
       passwordError: false,
       validity: [false, false]
-    }
+    };
   }
 
   updateValidity(index, value) {
@@ -57,17 +57,17 @@ class Login extends React.Component {
         <form onSubmit={e => { e.preventDefault(); this.login(); }}>
           <Card id="login-container">
             <center>
-              <CardHeader style={{ width: "70%" }} color="success">
+              <CardHeader style={{ width: '70%' }} color="success">
                 <h4><center>IRC Management System</center></h4>
               </CardHeader>
             </center>
 
-            <CardBody style={{ padding: "15px 45px 45px 45px" }}>
+            <CardBody style={{ padding: '15px 45px 45px 45px' }}>
               <div id="item-container">
                 <CustomInput
                   labelText="Email Address"
                   formControlProps={{ fullWidth: true }}
-                  inputProps={{ onChange: (e) => {this.checkEmail(e)} }}
+                  inputProps={{ onChange: (e) => { this.checkEmail(e); } }}
                   success={ this.state.validity[0] }
                   error={ !this.state.validity[0] }
                 />
@@ -78,7 +78,7 @@ class Login extends React.Component {
                   id="maskedInput"
                   labelText="Password"
                   formControlProps={{ fullWidth: true }}
-                  inputProps={{ onChange: (e) => {this.checkPassword(e)} }}
+                  inputProps={{ onChange: (e) => { this.checkPassword(e); } }}
                   success={ this.state.validity[1] }
                   error={ !this.state.validity[1] }
                 />
@@ -107,26 +107,26 @@ class Login extends React.Component {
   }
 
   login() {
-    if (this.state.validity.every((index) => {return index})) {
-      callBackendAPI('/api/login','post', {
+    if (this.state.validity.every((index) => { return index; })) {
+      callBackendAPI('/api/login', 'post', {
         email: this.state.email,
         password: this.state.password
       }).then(response => {
         if (response.error) {
           switch (response.error.substring(0, 9)) {
-            case "Error 404":
-              this.setState({ emailError: true });
-              this.updateValidity(0, false);
-              break;
-            case "Error 400":
-              this.setState({ passwordError: true });
-              this.updateValidity(1, false);
-              break;
+          case 'Error 404':
+            this.setState({ emailError: true });
+            this.updateValidity(0, false);
+            break;
+          case 'Error 400':
+            this.setState({ passwordError: true });
+            this.updateValidity(1, false);
+            break;
           }
         } else {
-          window.location.href = "/landing";
+          window.location.href = '/landing';
         }
-      })
+      });
     }
   }
 }

--- a/frontend-material/src/views/ShopList/ShopList.jsx
+++ b/frontend-material/src/views/ShopList/ShopList.jsx
@@ -1,40 +1,40 @@
-import React, { Component } from "react";
+import React, { Component } from 'react';
 
-import Header from "components/Shop_Header";
-import Products from "components/Products";
-import ErrorDialog from "components/ErrorDialog";
-import {callBackendAPI} from "components/CallBackendApi";
+import Header from 'components/Shop_Header';
+import Products from 'components/Products';
+import ErrorDialog from 'components/ErrorDialog';
+import { callBackendAPI } from 'components/CallBackendApi';
 
-import "assets/css/style.css";
+import 'assets/css/style.css';
 
-import withStyles from "@material-ui/core/styles/withStyles";
+import withStyles from '@material-ui/core/styles/withStyles';
 
 const styles = {
   cardCategoryWhite: {
-    "&,& a,& a:hover,& a:focus": {
-      color: "rgba(255,255,255,.62)",
-      margin: "0",
-      fontSize: "14px",
-      marginTop: "0",
-      marginBottom: "0"
+    '&,& a,& a:hover,& a:focus': {
+      color: 'rgba(255,255,255,.62)',
+      margin: '0',
+      fontSize: '14px',
+      marginTop: '0',
+      marginBottom: '0'
     },
-    "& a,& a:hover,& a:focus": {
-      color: "#FFFFFF"
+    '& a,& a:hover,& a:focus': {
+      color: '#FFFFFF'
     }
   },
   cardTitleWhite: {
-    color: "#FFFFFF",
-    marginTop: "0px",
-    minHeight: "auto",
-    fontWeight: "300",
+    color: '#FFFFFF',
+    marginTop: '0px',
+    minHeight: 'auto',
+    fontWeight: '300',
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
-    marginBottom: "3px",
-    textDecoration: "none",
-    "& small": {
-      color: "#777",
-      fontSize: "65%",
-      fontWeight: "400",
-      lineHeight: "1"
+    marginBottom: '3px',
+    textDecoration: 'none',
+    '& small': {
+      color: '#777',
+      fontSize: '65%',
+      fontWeight: '400',
+      lineHeight: '1'
     }
   }
 };
@@ -47,12 +47,12 @@ class ShopStore extends Component {
       cart: [],
       totalItems: 0,
       totalAmount: 0,
-      term: "",
+      term: '',
       cartBounce: false,
       quantity: 1,
       modalActive: false,
       open: false,
-      message: "",
+      message: '',
       clientId: 0
     };
     this.handleSearch = this.handleSearch.bind(this);
@@ -71,7 +71,7 @@ class ShopStore extends Component {
 
   // Fetch Initial Set of Products from external API
   getProducts() {
-    callBackendAPI("/api/transactions/getShopItems", "get")
+    callBackendAPI('/api/transactions/getShopItems', 'get')
       .then(response => {
         if (response.error != null) {
           this.setState({
@@ -96,7 +96,7 @@ class ShopStore extends Component {
   }
   // Mobile Search Reset
   handleMobileSearch() {
-    this.setState({ term: "" });
+    this.setState({ term: '' });
   }
 
   // Add to Cart
@@ -169,15 +169,15 @@ class ShopStore extends Component {
     });
   }
 
-  //Reset Quantity
+  // Reset Quantity
   updateQuantity(qty) {
     this.setState({
       quantity: qty
     });
   }
 
-  //Handles the checking out of items
-  //Currently searches by aliennumber
+  // Handles the checking out of items
+  // Currently searches by aliennumber
   handleCheckout() {
     let postedCart = [];
     let userID;
@@ -196,15 +196,15 @@ class ShopStore extends Component {
           if (response[i].alienNumber === Number(this.state.clientId)) {
             callBackendAPI('/api/transactions/addTransaction', 'post', {
               transaction: {
-                volunteerItems:[],
+                volunteerItems: [],
                 shopItems: postedCart,
                 authorizedUser: userID,
                 clientId: response[i]._id,
-                type: "SHOP"
+                type: 'SHOP'
               }
             }).then(response => {
-              if (response) {console.log(response);}
-            })
+              if (response) { console.log(response); }
+            });
             searching = false;
           }
           i++;
@@ -212,7 +212,7 @@ class ShopStore extends Component {
         if (searching) {
           this.setState({
             open: true,
-            message: "Invalid Client Id!"
+            message: 'Invalid Client Id!'
           });
         }
       });

--- a/frontend-material/src/views/ShopModify/ShopModify.jsx
+++ b/frontend-material/src/views/ShopModify/ShopModify.jsx
@@ -1,39 +1,39 @@
-import React, { Component } from "react";
-import { Redirect } from "react-router-dom";
-import Header from "components/Shop_Header";
-import Products from "components/Products";
-import "assets/css/style.css";
-import withStyles from "@material-ui/core/styles/withStyles";
-import {callBackendAPI} from "components/CallBackendApi";
-import ErrorDialog from "components/ErrorDialog";
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+import Header from 'components/Shop_Header';
+import Products from 'components/Products';
+import 'assets/css/style.css';
+import withStyles from '@material-ui/core/styles/withStyles';
+import { callBackendAPI } from 'components/CallBackendApi';
+import ErrorDialog from 'components/ErrorDialog';
 
 
 const styles = {
   cardCategoryWhite: {
-    "&,& a,& a:hover,& a:focus": {
-      color: "rgba(255,255,255,.62)",
-      margin: "0",
-      fontSize: "14px",
-      marginTop: "0",
-      marginBottom: "0"
+    '&,& a,& a:hover,& a:focus': {
+      color: 'rgba(255,255,255,.62)',
+      margin: '0',
+      fontSize: '14px',
+      marginTop: '0',
+      marginBottom: '0'
     },
-    "& a,& a:hover,& a:focus": {
-      color: "#FFFFFF"
+    '& a,& a:hover,& a:focus': {
+      color: '#FFFFFF'
     }
   },
   cardTitleWhite: {
-    color: "#FFFFFF",
-    marginTop: "0px",
-    minHeight: "auto",
-    fontWeight: "300",
+    color: '#FFFFFF',
+    marginTop: '0px',
+    minHeight: 'auto',
+    fontWeight: '300',
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
-    marginBottom: "3px",
-    textDecoration: "none",
-    "& small": {
-      color: "#777",
-      fontSize: "65%",
-      fontWeight: "400",
-      lineHeight: "1"
+    marginBottom: '3px',
+    textDecoration: 'none',
+    '& small': {
+      color: '#777',
+      fontSize: '65%',
+      fontWeight: '400',
+      lineHeight: '1'
     }
   }
 };
@@ -45,8 +45,8 @@ class ShopMod extends Component {
       products: [],
       totalItems: 0,
       totalAmount: 0,
-      term: "",
-      category: "",
+      term: '',
+      category: '',
       cartBounce: false,
       quantity: 1,
       modalActive: false,
@@ -66,7 +66,7 @@ class ShopMod extends Component {
   }
   // Fetch Initial Set of Products from external API
   getProducts() {
-    callBackendAPI("/api/transactions/getShopItems", "get")
+    callBackendAPI('/api/transactions/getShopItems', 'get')
       .then(response => {
         if (response.error != null) {
           this.setState({
@@ -94,7 +94,7 @@ class ShopMod extends Component {
   }
   // Mobile Search Reset
   handleMobileSearch() {
-    this.setState({ term: "" });
+    this.setState({ term: '' });
   }
   // Filter by Category
   handleCategory(event) {
@@ -102,9 +102,9 @@ class ShopMod extends Component {
     console.log(this.state.category);
   }
 
-  //Reset Quantity
+  // Reset Quantity
   updateQuantity(qty) {
-    console.log("quantity added...");
+    console.log('quantity added...');
     this.setState({
       quantity: qty
     });
@@ -114,11 +114,11 @@ class ShopMod extends Component {
   handleUpdateProduct(e, type, id, value) {
     let up_products = this.state.products;
     let index = up_products.findIndex(x => x.id === id);
-    if (type === "name") {
+    if (type === 'name') {
       up_products[index].name = value;
-    } else if (type === "price") {
+    } else if (type === 'price') {
       up_products[index].price = parseInt(value, 10);
-    } else if (type === "matched"){
+    } else if (type === 'matched') {
       up_products[index].percentageMatched = value;
     }
     this.setState({
@@ -138,23 +138,23 @@ class ShopMod extends Component {
   }
 
 
-  //This method handles if the admin wants to reset their changes
+  // This method handles if the admin wants to reset their changes
   handleReset() {
-      this.setState({
-        products: this.state.orig_products.slice()
-      });
+    this.setState({
+      products: this.state.orig_products.slice()
+    });
   }
 
-  //This method handles if the admin wants to save their changes to the database
+  // This method handles if the admin wants to save their changes to the database
   handleSave() {
     callBackendAPI('/api/transactions/updateItems', 'post', {
-      itemType: "SHOP",
+      itemType: 'SHOP',
       updatedItems: this.state.products
     }).then(response => {
       this.setState({
-        redirect: "/shop"
+        redirect: '/shop'
       });
-    })
+    });
   }
 
   handleClose() {
@@ -166,7 +166,7 @@ class ShopMod extends Component {
 
   render() {
     if (this.state.redirect !== false) {
-      return <Redirect to={this.state.redirect} />
+      return <Redirect to={this.state.redirect} />;
     }
 
     return (

--- a/frontend-material/src/views/SignUp/SignUp.jsx
+++ b/frontend-material/src/views/SignUp/SignUp.jsx
@@ -1,26 +1,26 @@
-import React from "react";
-import "assets/css/style.css";
+import React from 'react';
+import 'assets/css/style.css';
 
-import Card from "components/Card/Card.jsx";
-import CardBody from "components/Card/CardBody.jsx";
-import CardHeader from "components/Card/CardHeader.jsx";
-import Button from "components/CustomButtons/Button.jsx";
-import CustomInput from "components/CustomInput/CustomInput.jsx";
+import Card from 'components/Card/Card.jsx';
+import CardBody from 'components/Card/CardBody.jsx';
+import CardHeader from 'components/Card/CardHeader.jsx';
+import Button from 'components/CustomButtons/Button.jsx';
+import CustomInput from 'components/CustomInput/CustomInput.jsx';
 
-import {Link} from "react-router-dom";
-import {callBackendAPI} from "components/CallBackendApi";
-import withStyles from "@material-ui/core/styles/withStyles";
-import dashboardStyle from "assets/jss/material-dashboard-react/views/dashboardStyle.jsx";
+import { Link } from 'react-router-dom';
+import { callBackendAPI } from 'components/CallBackendApi';
+import withStyles from '@material-ui/core/styles/withStyles';
+import dashboardStyle from 'assets/jss/material-dashboard-react/views/dashboardStyle.jsx';
 
 class SignUp extends React.Component {
   constructor() {
     super();
     this.state = {
-      fname: "",
-      lname: "",
-      email: "",
-      password: "",
-      confirmation: "",
+      fname: '',
+      lname: '',
+      email: '',
+      password: '',
+      confirmation: '',
       emailInUse: false,
       validity: [false, false, false, false, false]
     };
@@ -82,18 +82,18 @@ class SignUp extends React.Component {
         <form onSubmit={e => { e.preventDefault(); this.signup(); }}>
           <Card id="signup-container">
             <center>
-              <CardHeader style={{ width: "70%" }} color="success">
+              <CardHeader style={{ width: '70%' }} color="success">
                 <h4><center>Create an Account</center></h4>
               </CardHeader>
             </center>
 
-            <CardBody style={{ padding: "15px 45px 45px 45px" }}>
+            <CardBody style={{ padding: '15px 45px 45px 45px' }}>
               <div id="item-container">
                 <div id="name-container" className="left">
                   <CustomInput
                     labelText="First Name"
                     formControlProps={{ fullWidth: false }}
-                    inputProps={{ onChange: (e) => {this.fnameCheck(e)} }}
+                    inputProps={{ onChange: (e) => { this.fnameCheck(e); } }}
                     success={ this.state.validity[0] }
                     error={ !this.state.validity[0] }
                   />
@@ -102,7 +102,7 @@ class SignUp extends React.Component {
                   <CustomInput
                     labelText="Last Name"
                     formControlProps={{ fullWidth: false }}
-                    inputProps={{ onChange: (e) => {this.lnameCheck(e)} }}
+                    inputProps={{ onChange: (e) => { this.lnameCheck(e); } }}
                     success={ this.state.validity[1] }
                     error={ !this.state.validity[1] }
                   />
@@ -110,7 +110,7 @@ class SignUp extends React.Component {
                 <CustomInput
                   labelText="Email Address"
                   formControlProps={{ fullWidth: true }}
-                  inputProps={{ onChange: (e) => {this.emailCheck(e)} }}
+                  inputProps={{ onChange: (e) => { this.emailCheck(e); } }}
                   success={ this.state.validity[2] }
                   error={ !this.state.validity[2] }
                 />
@@ -121,7 +121,7 @@ class SignUp extends React.Component {
                   id="maskedInput"
                   labelText="Password"
                   formControlProps={{ fullWidth: true }}
-                  inputProps={{ onChange: (e) => {this.passwordCheck(e)} }}
+                  inputProps={{ onChange: (e) => { this.passwordCheck(e); } }}
                   success={ this.state.validity[3] }
                   error={ !this.state.validity[3] }
                 />
@@ -129,7 +129,7 @@ class SignUp extends React.Component {
                   id="maskedInput"
                   labelText="Confirm Password"
                   formControlProps={{ fullWidth: true }}
-                  inputProps={{ onChange: (e) => {this.confirmCheck(e)} }}
+                  inputProps={{ onChange: (e) => { this.confirmCheck(e); } }}
                   success={ this.state.validity[4] }
                   error={ !this.state.validity[4] }
                 />
@@ -155,7 +155,7 @@ class SignUp extends React.Component {
   }
 
   signup() {
-    if (this.state.validity.every(index => {return index})) {
+    if (this.state.validity.every(index => { return index; })) {
       callBackendAPI('/api/signup', 'post', {
         firstName: this.state.fname,
         lastName: this.state.lname,
@@ -166,11 +166,11 @@ class SignUp extends React.Component {
           this.setState({ emailInUse: true });
           this.updateValidity(2, false);
         } else {
-          callBackendAPI('/api/login','post', {
+          callBackendAPI('/api/login', 'post', {
             email: this.state.email,
             password: this.state.password
           }).then(() => {
-            window.location.href = "/landing";
+            window.location.href = '/landing';
           });
         }
       });

--- a/frontend-material/src/views/TimeList/TimeList.jsx
+++ b/frontend-material/src/views/TimeList/TimeList.jsx
@@ -1,40 +1,40 @@
-import React, { Component } from "react";
+import React, { Component } from 'react';
 
-import Header from "components/Shop_Header";
-import Products from "components/Products";
-import ErrorDialog from "components/ErrorDialog";
-import {callBackendAPI} from "components/CallBackendApi";
+import Header from 'components/Shop_Header';
+import Products from 'components/Products';
+import ErrorDialog from 'components/ErrorDialog';
+import { callBackendAPI } from 'components/CallBackendApi';
 
-import "assets/css/style.css";
+import 'assets/css/style.css';
 
-import withStyles from "@material-ui/core/styles/withStyles";
+import withStyles from '@material-ui/core/styles/withStyles';
 
 const styles = {
   cardCategoryWhite: {
-    "&,& a,& a:hover,& a:focus": {
-      color: "rgba(255,255,255,.62)",
-      margin: "0",
-      fontSize: "14px",
-      marginTop: "0",
-      marginBottom: "0"
+    '&,& a,& a:hover,& a:focus': {
+      color: 'rgba(255,255,255,.62)',
+      margin: '0',
+      fontSize: '14px',
+      marginTop: '0',
+      marginBottom: '0'
     },
-    "& a,& a:hover,& a:focus": {
-      color: "#FFFFFF"
+    '& a,& a:hover,& a:focus': {
+      color: '#FFFFFF'
     }
   },
   cardTitleWhite: {
-    color: "#FFFFFF",
-    marginTop: "0px",
-    minHeight: "auto",
-    fontWeight: "300",
+    color: '#FFFFFF',
+    marginTop: '0px',
+    minHeight: 'auto',
+    fontWeight: '300',
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
-    marginBottom: "3px",
-    textDecoration: "none",
-    "& small": {
-      color: "#777",
-      fontSize: "65%",
-      fontWeight: "400",
-      lineHeight: "1"
+    marginBottom: '3px',
+    textDecoration: 'none',
+    '& small': {
+      color: '#777',
+      fontSize: '65%',
+      fontWeight: '400',
+      lineHeight: '1'
     }
   }
 };
@@ -47,12 +47,12 @@ class ShopStore extends Component {
       cart: [],
       totalItems: 0,
       totalAmount: 0,
-      term: "",
+      term: '',
       cartBounce: false,
       quantity: 1,
       modalActive: false,
       open: false,
-      message: "",
+      message: '',
       clientId: 0
     };
     this.handleSearch = this.handleSearch.bind(this);
@@ -71,7 +71,7 @@ class ShopStore extends Component {
 
   // Fetch Initial Set of Products from external API
   getProducts() {
-    callBackendAPI("/api/transactions/getVolunteerItems", "get")
+    callBackendAPI('/api/transactions/getVolunteerItems', 'get')
       .then(response => {
         if (response.error != null) {
           this.setState({
@@ -96,7 +96,7 @@ class ShopStore extends Component {
   }
   // Mobile Search Reset
   handleMobileSearch() {
-    this.setState({ term: "" });
+    this.setState({ term: '' });
   }
 
   // Add to Cart
@@ -169,15 +169,15 @@ class ShopStore extends Component {
     });
   }
 
-  //Reset Quantity
+  // Reset Quantity
   updateQuantity(qty) {
     this.setState({
       quantity: qty
     });
   }
 
-  //Handles the checking out of items
-  //Currently searches by aliennumber
+  // Handles the checking out of items
+  // Currently searches by aliennumber
   handleCheckout() {
     let postedCart = [];
     let userID;
@@ -196,15 +196,15 @@ class ShopStore extends Component {
           if (response[i].alienNumber === Number(this.state.clientId)) {
             callBackendAPI('/api/transactions/addTransaction', 'post', {
               transaction: {
-                volunteerItems:postedCart,
+                volunteerItems: postedCart,
                 shopItems: [],
                 authorizedUser: userID,
                 clientId: response[i]._id,
-                type: "VOLUNTEER"
+                type: 'VOLUNTEER'
               }
             }).then(response => {
-              if (response) {console.log(response);}
-            })
+              if (response) { console.log(response); }
+            });
             searching = false;
           }
           i++;
@@ -212,7 +212,7 @@ class ShopStore extends Component {
         if (searching) {
           this.setState({
             open: true,
-            message: "Invalid Client Id!"
+            message: 'Invalid Client Id!'
           });
         }
       });

--- a/frontend-material/src/views/TimeModify/TimeModify.jsx
+++ b/frontend-material/src/views/TimeModify/TimeModify.jsx
@@ -1,39 +1,39 @@
-import React, { Component } from "react";
-import { Redirect } from "react-router-dom";
-import Header from "components/Shop_Header";
-import Products from "components/Products";
-import "assets/css/style.css";
-import withStyles from "@material-ui/core/styles/withStyles";
-import {callBackendAPI} from "components/CallBackendApi";
-import ErrorDialog from "components/ErrorDialog";
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+import Header from 'components/Shop_Header';
+import Products from 'components/Products';
+import 'assets/css/style.css';
+import withStyles from '@material-ui/core/styles/withStyles';
+import { callBackendAPI } from 'components/CallBackendApi';
+import ErrorDialog from 'components/ErrorDialog';
 
 
 const styles = {
   cardCategoryWhite: {
-    "&,& a,& a:hover,& a:focus": {
-      color: "rgba(255,255,255,.62)",
-      margin: "0",
-      fontSize: "14px",
-      marginTop: "0",
-      marginBottom: "0"
+    '&,& a,& a:hover,& a:focus': {
+      color: 'rgba(255,255,255,.62)',
+      margin: '0',
+      fontSize: '14px',
+      marginTop: '0',
+      marginBottom: '0'
     },
-    "& a,& a:hover,& a:focus": {
-      color: "#FFFFFF"
+    '& a,& a:hover,& a:focus': {
+      color: '#FFFFFF'
     }
   },
   cardTitleWhite: {
-    color: "#FFFFFF",
-    marginTop: "0px",
-    minHeight: "auto",
-    fontWeight: "300",
+    color: '#FFFFFF',
+    marginTop: '0px',
+    minHeight: 'auto',
+    fontWeight: '300',
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
-    marginBottom: "3px",
-    textDecoration: "none",
-    "& small": {
-      color: "#777",
-      fontSize: "65%",
-      fontWeight: "400",
-      lineHeight: "1"
+    marginBottom: '3px',
+    textDecoration: 'none',
+    '& small': {
+      color: '#777',
+      fontSize: '65%',
+      fontWeight: '400',
+      lineHeight: '1'
     }
   }
 };
@@ -45,8 +45,8 @@ class ShopMod extends Component {
       products: [],
       totalItems: 0,
       totalAmount: 0,
-      term: "",
-      category: "",
+      term: '',
+      category: '',
       cartBounce: false,
       quantity: 1,
       modalActive: false,
@@ -66,7 +66,7 @@ class ShopMod extends Component {
   }
   // Fetch Initial Set of Products from external API
   getProducts() {
-    callBackendAPI("/api/transactions/getVolunteerItems", "get")
+    callBackendAPI('/api/transactions/getVolunteerItems', 'get')
       .then(response => {
         if (response.error != null) {
           this.setState({
@@ -94,7 +94,7 @@ class ShopMod extends Component {
   }
   // Mobile Search Reset
   handleMobileSearch() {
-    this.setState({ term: "" });
+    this.setState({ term: '' });
   }
   // Filter by Category
   handleCategory(event) {
@@ -102,9 +102,9 @@ class ShopMod extends Component {
     console.log(this.state.category);
   }
 
-  //Reset Quantity
+  // Reset Quantity
   updateQuantity(qty) {
-    console.log("quantity added...");
+    console.log('quantity added...');
     this.setState({
       quantity: qty
     });
@@ -114,11 +114,11 @@ class ShopMod extends Component {
   handleUpdateProduct(e, type, id, value) {
     let up_products = this.state.products;
     let index = up_products.findIndex(x => x.id === id);
-    if (type === "name") {
+    if (type === 'name') {
       up_products[index].name = value;
-    } else if (type === "price") {
+    } else if (type === 'price') {
       up_products[index].price = parseInt(value, 10);
-    } else if (type === "matched"){
+    } else if (type === 'matched') {
       up_products[index].percentageMatched = value;
     }
     this.setState({
@@ -138,23 +138,23 @@ class ShopMod extends Component {
   }
 
 
-  //This method handles if the admin wants to reset their changes
+  // This method handles if the admin wants to reset their changes
   handleReset() {
-      this.setState({
-        products: this.state.orig_products.slice()
-      });
+    this.setState({
+      products: this.state.orig_products.slice()
+    });
   }
 
-  //This method handles if the admin wants to save their changes to the database
+  // This method handles if the admin wants to save their changes to the database
   handleSave() {
     callBackendAPI('/api/transactions/updateItems', 'post', {
-      itemType: "VOLUNTEER",
+      itemType: 'VOLUNTEER',
       updatedItems: this.state.products
     }).then(response => {
       this.setState({
-        redirect: "/time"
+        redirect: '/time'
       });
-    })
+    });
   }
 
   handleClose() {
@@ -166,7 +166,7 @@ class ShopMod extends Component {
 
   render() {
     if (this.state.redirect !== false) {
-      return <Redirect to={this.state.redirect} />
+      return <Redirect to={this.state.redirect} />;
     }
 
     return (

--- a/frontend-material/src/views/UserProfile/UserProfile.jsx
+++ b/frontend-material/src/views/UserProfile/UserProfile.jsx
@@ -1,35 +1,35 @@
-import React, { Component } from "react";
+import React, { Component } from 'react';
 // @material-ui/core components
-import withStyles from "@material-ui/core/styles/withStyles";
+import withStyles from '@material-ui/core/styles/withStyles';
 // core components
-import GridItem from "components/Grid/GridItem.jsx";
-import GridContainer from "components/Grid/GridContainer.jsx";
-import CustomInput from "components/CustomInput/CustomInput.jsx";
-import Button from "components/CustomButtons/Button.jsx";
-import Card from "components/Card/Card.jsx";
-import CardHeader from "components/Card/CardHeader.jsx";
-import CardBody from "components/Card/CardBody.jsx";
-import CardFooter from "components/Card/CardFooter.jsx";
+import GridItem from 'components/Grid/GridItem.jsx';
+import GridContainer from 'components/Grid/GridContainer.jsx';
+import CustomInput from 'components/CustomInput/CustomInput.jsx';
+import Button from 'components/CustomButtons/Button.jsx';
+import Card from 'components/Card/Card.jsx';
+import CardHeader from 'components/Card/CardHeader.jsx';
+import CardBody from 'components/Card/CardBody.jsx';
+import CardFooter from 'components/Card/CardFooter.jsx';
 
-import {callBackendAPI} from "components/CallBackendApi";
-import ErrorDialog from "components/ErrorDialog";
+import { callBackendAPI } from 'components/CallBackendApi';
+import ErrorDialog from 'components/ErrorDialog';
 
 const styles = {
   cardCategoryWhite: {
-    color: "rgba(255,255,255,.62)",
-    margin: "0",
-    fontSize: "14px",
-    marginTop: "0",
-    marginBottom: "0"
+    color: 'rgba(255,255,255,.62)',
+    margin: '0',
+    fontSize: '14px',
+    marginTop: '0',
+    marginBottom: '0'
   },
   cardTitleWhite: {
-    color: "#FFFFFF",
-    marginTop: "0px",
-    minHeight: "auto",
-    fontWeight: "300",
+    color: '#FFFFFF',
+    marginTop: '0px',
+    minHeight: 'auto',
+    fontWeight: '300',
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
-    marginBottom: "3px",
-    textDecoration: "none"
+    marginBottom: '3px',
+    textDecoration: 'none'
   }
 };
 
@@ -39,10 +39,10 @@ class UserProfile extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      password: "",
-      confirm: "",
+      password: '',
+      confirm: '',
       open: false
-    }
+    };
 
     this.handleResetPassword = this.handleResetPassword.bind(this);
     this.handlePasswordChange = this.handlePasswordChange.bind(this);
@@ -62,8 +62,8 @@ class UserProfile extends Component {
       callBackendAPI('/api/changePassword', 'post', {
         password: this.state.password
       }).then(response => {
-        if (response) {console.log(response);}
-      })
+        if (response) { console.log(response); }
+      });
     } else {
       this.setState({
         open: true
@@ -80,52 +80,52 @@ class UserProfile extends Component {
   render() {
     return (
       <div>
-          <GridItem xs={12} sm={12} md={12}>
-            <Card>
-              <CardHeader color="primary">
-                <h4>Edit Profile</h4>
-                <p>Update password here</p>
-              </CardHeader>
-              <CardBody>
-                <GridContainer>
-                  <GridItem xs={12} sm={12} md={6}>
-                    <CustomInput
-                      labelText="New password"
-                      id="first-name"
-                      inputProps={{
-                        onChange:(e) => this.handlePasswordChange(e),
-                        type: "password"
-                      }}
-                      formControlProps={{
-                        fullWidth: true
-                      }}
-                    />
-                  </GridItem>
-                  <GridItem xs={12} sm={12} md={6}>
-                    <CustomInput
-                      labelText="Confirm"
-                      id="last-name"
-                      inputProps={{
-                        onChange:(e) => this.handleConfirmChange(e),
-                        type: "password"
-                      }}
-                      formControlProps={{
-                        fullWidth: true
-                      }}
-                    />
-                  </GridItem>
-                </GridContainer>
-              </CardBody>
-              <CardFooter>
-                <Button onClick={() => this.handleResetPassword()} color="primary">Reset Password</Button>
-              </CardFooter>
-            </Card>
-          </GridItem>
-          <ErrorDialog
-            open = {this.state.open}
-            handleClose = {this.handleClose}
-            message = {"Your passwords don't match!"}
-          />
+        <GridItem xs={12} sm={12} md={12}>
+          <Card>
+            <CardHeader color="primary">
+              <h4>Edit Profile</h4>
+              <p>Update password here</p>
+            </CardHeader>
+            <CardBody>
+              <GridContainer>
+                <GridItem xs={12} sm={12} md={6}>
+                  <CustomInput
+                    labelText="New password"
+                    id="first-name"
+                    inputProps={{
+                      onChange: (e) => this.handlePasswordChange(e),
+                      type: 'password'
+                    }}
+                    formControlProps={{
+                      fullWidth: true
+                    }}
+                  />
+                </GridItem>
+                <GridItem xs={12} sm={12} md={6}>
+                  <CustomInput
+                    labelText="Confirm"
+                    id="last-name"
+                    inputProps={{
+                      onChange: (e) => this.handleConfirmChange(e),
+                      type: 'password'
+                    }}
+                    formControlProps={{
+                      fullWidth: true
+                    }}
+                  />
+                </GridItem>
+              </GridContainer>
+            </CardBody>
+            <CardFooter>
+              <Button onClick={() => this.handleResetPassword()} color="primary">Reset Password</Button>
+            </CardFooter>
+          </Card>
+        </GridItem>
+        <ErrorDialog
+          open = {this.state.open}
+          handleClose = {this.handleClose}
+          message = {"Your passwords don't match!"}
+        />
       </div>
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.7.0"
@@ -717,6 +718,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -773,6 +775,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
       "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -790,6 +793,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -879,6 +883,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
       "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
+      "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
@@ -895,6 +900,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
           "requires": {
             "esutils": "^2.0.2"
           }
@@ -970,7 +976,8 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -1197,7 +1204,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1238,6 +1246,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1251,7 +1260,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "http-errors": {
       "version": "1.6.3",
@@ -1346,12 +1356,14 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -1384,6 +1396,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -1392,6 +1405,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -1405,7 +1419,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -1456,6 +1471,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
       "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "object.assign": "^4.1.0"
@@ -1544,6 +1560,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -1761,22 +1778,26 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -1788,6 +1809,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -1799,6 +1821,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
       "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.15.0",
@@ -1810,6 +1833,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -1932,7 +1956,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -1965,6 +1990,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -2010,7 +2036,8 @@
     "react-is": {
       "version": "16.10.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==",
+      "dev": true
     },
     "regexp-clone": {
       "version": "0.0.1",
@@ -2036,6 +2063,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -2231,6 +2259,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
       "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -2240,6 +2269,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
       "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -13,10 +33,79 @@
         "negotiator": "0.6.1"
       }
     },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.1",
@@ -25,6 +114,12 @@
       "requires": {
         "lodash": "^4.17.10"
       }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt": {
       "version": "3.0.1",
@@ -478,6 +573,16 @@
         "type-is": "~1.6.16"
       }
     },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "bson": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
@@ -492,6 +597,65 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -522,12 +686,39 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
       }
     },
     "depd": {
@@ -539,6 +730,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dotenv": {
       "version": "6.1.0",
@@ -558,15 +758,219 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "es-abstract": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+      "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
+      "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.2.1",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.0.0",
+        "acorn-jsx": "^5.0.2",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -678,6 +1082,64 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -699,6 +1161,23 @@
         }
       }
     },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -708,6 +1187,71 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -728,15 +1272,162 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      }
+    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "jsonwebtoken": {
       "version": "8.3.0",
@@ -759,6 +1450,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "jwa": {
@@ -784,6 +1484,16 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
       "integrity": "sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg=="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.15",
@@ -830,6 +1540,14 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -867,6 +1585,36 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
         "mime-db": "~1.36.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
       }
     },
     "mongodb": {
@@ -977,20 +1725,97 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
       "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
+      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -998,6 +1823,53 @@
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
       }
     },
     "parseurl": {
@@ -1045,6 +1917,23 @@
         "util": "^0.10.3"
       }
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -1055,10 +1944,32 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
     },
     "proxy-addr": {
       "version": "2.0.4",
@@ -1068,6 +1979,12 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -1090,10 +2007,21 @@
         "unpipe": "1.0.0"
       }
     },
+    "react-is": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+    },
     "regexp-clone": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
     },
     "require_optional": {
       "version": "1.0.1",
@@ -1104,10 +2032,55 @@
         "semver": "^5.1.0"
       }
     },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -1176,6 +2149,38 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
@@ -1190,10 +2195,148 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.16",
@@ -1209,6 +2352,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -1222,10 +2374,46 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
     "dotenv": "^6.1.0",
+    "eslint-plugin-react": "^7.16.0",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.3.0",
     "mongoose": "^5.3.0",
@@ -36,5 +37,8 @@
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",
     "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "eslint": "^6.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
     "dotenv": "^6.1.0",
-    "eslint-plugin-react": "^7.16.0",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.3.0",
     "mongoose": "^5.3.0",
@@ -39,6 +38,7 @@
     "path": "^0.12.7"
   },
   "devDependencies": {
-    "eslint": "^6.5.1"
+    "eslint": "^6.5.1",
+    "eslint-plugin-react": "^7.16.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	plugins: [require("autoprefixer")]
+    plugins: [require('autoprefixer')]
 };

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@
 
 // Node/Express imports
 const config = require('./config');
-const express = require('express')
+const express = require('express');
 const mongoose = require('mongoose');
 const path = require('path');
 const app = express();
@@ -20,14 +20,14 @@ mongoose.Promise = global.Promise;
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/api', api);
 
-//We still need to get front end connected to backend properly
+// We still need to get front end connected to backend properly
 // app.get('/*', (req, res) => {
 //   res.sendFile(__dirname + '/frontend-material/public/index.html');
 // });
 
 // Hosting
 app.listen(port, err => {
-  err ? console.error(err) : console.info(`Dragons are on port ${port}`);
+    err ? console.error(err) : console.info(`Dragons are on port ${port}`);
 });
 
 module.exports = app;


### PR DESCRIPTION
Add eslint style guidelines. Added two npm packages: eslint and eslint-plugin-react. It also needs babel-eslint for frontend-material, but that should already be installed thanks to Creative Tim. Automatically applied style changes.

Also fixed some undefined variables: one instance of `JWTstrategy` instead of `JWTStrategy`, and `error = ` in a function call.

Added to README.md:

> Run `npx eslint --fix /path_to/irc/` or `npx eslint --ext js,jsx --fix /path_to/irc/` (including .jsx files) to check and fix the style of your code. Use semicolons and single quotes. See .eslintrc.yml, frontend-material/.eslintrc.yml, and .eslintignore for details on the style guidelines. If eslint is throwing up an error based on a bad style guideline, you can add `  name-of-style-error: off` to the bottom of .eslintrc.yml.

There might be some bad style guidelines because it's extending eslint:recommended and plugin:react/recommended, and I haven't personally vetted all the rules there. I disabled some like no-console, react/prop-types, and react/no-useless-escapes (because it was considering escapes in regex to be useless).